### PR TITLE
ValidateMustStatement: concurrent map writes fix

### DIFF
--- a/pkg/datastore/data_rpc.go
+++ b/pkg/datastore/data_rpc.go
@@ -508,7 +508,7 @@ func (d *Datastore) validateMustStatement(ctx context.Context, candidateName str
 			machine := xpath.NewMachine(exprStr, prog, exprStr)
 
 			// run the must statement evaluation virtual machine
-			res1 := xpath.NewCtxFromCurrent(ctx, machine, p.Elem, d.getValidationClient(), candidateName).EnableValidation().Run()
+			res1 := xpath.NewCtxFromCurrent(ctx, machine, p.Elem, d.getValidationClient(), candidateName).Run()
 
 			// retrieve the boolean result of the execution
 			result, err := res1.GetBoolResult()


### PR DESCRIPTION
Remove setting the validation flag to true. The flag is not meant to enable the Must-Statement Validation but the internal validation of input output parameters of functions xpath functions used in the Must statements. see: https://github.com/iptecharch/yang-parser/blob/3a7a360ac65ad9fc51b4f906bc3e91814ad68c7f/xpath/context.go#L379

Fixes #75