### PR TITLE
choiceCasesResolver: fixing GetElemName()

### DIFF
--- a/pkg/tree/choice_case_resolver.go
+++ b/pkg/tree/choice_case_resolver.go
@@ -57,8 +57,8 @@ type choiceCasesResolver struct {
 // GetElementNames retrieve all the Element names involved in the Choice
 func (c *choiceCasesResolver) GetElementNames() []string {
 	result := make([]string, 0, len(c.cases))
-	for k := range c.cases {
-		result = append(result, k)
+	for elemName := range c.elementToCaseMapping {
+		result = append(result, elemName)
 	}
 	return result
 }


### PR DESCRIPTION
GetElemName() returned case names instead of element names of the respective cases.