### PR TITLE
ChoiceCaseResolver: bug with running

### DIFF
--- a/pkg/datastore/intent_rpc_set_update.go
+++ b/pkg/datastore/intent_rpc_set_update.go
@@ -170,13 +170,13 @@ func (d *Datastore) SetIntentUpdate(ctx context.Context, req *sdcpb.SetIntentReq
 		return nil, err
 	}
 
-	log.Debugf("finish insertion phase")
-	root.FinishInsertionPhase()
-
 	err = d.populateTreeWithRunning(ctx, tc, root)
 	if err != nil {
 		return nil, err
 	}
+
+	log.Debugf("finish insertion phase")
+	root.FinishInsertionPhase()
 
 	fmt.Printf("Tree before Validate:%s\n", root.String())
 


### PR DESCRIPTION
ChoiceCaseResolver: Case priorities also need to account for running, hence the calc had to be moved behind populating tree with running