### PR TITLE
XML generation fix

### DIFF
--- a/pkg/tree/sharedEntryAttributes.go
+++ b/pkg/tree/sharedEntryAttributes.go
@@ -153,9 +153,9 @@ func (s *sharedEntryAttributes) FilterChilds(keys map[string]string) ([]Entry, e
 			}
 		} else {
 			// this is basically the wildcard case, so go through all childs and add them
+			result = make([]Entry, 0, len(processEntries))
 			for _, entry := range processEntries {
 				childs := entry.getChildren()
-				result = make([]Entry, 0, len(childs))
 				for _, v := range childs {
 					// hence we add all the existing childs to the result list
 					result = append(result, v)


### PR DESCRIPTION
This PR fixes an issue where children of a list might be missing from the generated xml even if it exists in the tree.

This was due to the `result` slice being cleared too early before the processEntries array has been iterated through, so this PR moves the clearing/allocation of the `result` slice outside of the `for` loop