### PR TITLE
JSON fixes

### DIFF
--- a/pkg/utils/converter.go
+++ b/pkg/utils/converter.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -66,14 +67,19 @@ func (c *Converter) ExpandUpdate(ctx context.Context, upd *sdcpb.Update, include
 		log.Debugf("expanding update %v on container %q", upd, rsp.Container.Name)
 		var v interface{}
 		var err error
+		var jsonDecoder *json.Decoder
 		switch upd.GetValue().Value.(type) {
 		case *sdcpb.TypedValue_JsonIetfVal:
-			err = json.Unmarshal(upd.GetValue().GetJsonIetfVal(), &v)
+			jsonDecoder = json.NewDecoder(bytes.NewReader(upd.GetValue().GetJsonIetfVal()))
 		case *sdcpb.TypedValue_JsonVal:
-			err = json.Unmarshal(upd.GetValue().GetJsonVal(), &v)
+			jsonDecoder = json.NewDecoder(bytes.NewReader(upd.GetValue().GetJsonVal()))
 		default:
 			return []*sdcpb.Update{upd}, nil
 		}
+		// don't decode into float64 but keep as a string
+		// this solves issues created by reading long integers
+		jsonDecoder.UseNumber()
+		err = jsonDecoder.Decode(&v)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/value.go
+++ b/pkg/utils/value.go
@@ -90,6 +90,9 @@ func GetJsonValue(tv *sdcpb.TypedValue, ietf bool) (any, error) {
 			return tv.GetIdentityrefVal().JsonIetfString(), nil
 		}
 		return GetSchemaValue(tv)
+	case *sdcpb.TypedValue_DecimalVal:
+		// TODO have a String() function on the *sdcpb.TypedValue_DecimalVal type?
+		return TypedValueToString(tv), nil
 	default:
 		return GetSchemaValue(tv)
 	}


### PR DESCRIPTION
This PR addresses 2 issues related to numbers:
- correctly get JSON value for DecimalVals -> previously this would turn a map to a string, now it processes it correctly
- make json.Unmarshal read numbers as strings -> json would use floats for large integers, this keeps them as strings avoiding cases where it would represent something like `key: 1000000` as `key: 1e+06` which can not be parsed by the strconv functions