### PR TITLE
Bug: Fix validateLeafListValue()

### DIFF
--- a/pkg/datastore/data_rpc.go
+++ b/pkg/datastore/data_rpc.go
@@ -732,12 +732,21 @@ func validateLeafTypeValue(lt *sdcpb.SchemaLeafType, v any) error {
 }
 
 func validateLeafListValue(ll *sdcpb.LeafListSchema, v any) error {
-	// TODO: validate Leaflist
-	// TODO: eval must statements
-	// for _, must := range ll.MustStatements {
-	// 	_ = must
-	// }
-	return validateLeafTypeValue(ll.GetType(), v)
+	switch vTyped := v.(type) {
+	case *sdcpb.ScalarArray:
+		for _, elem := range vTyped.Element {
+			val, err := utils.GetSchemaValue(elem)
+			if err != nil {
+				return err
+			}
+			err = validateLeafTypeValue(ll.GetType(), val)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (d *Datastore) doSubscribeOnce(ctx context.Context, subscription *sdcpb.Subscription, stream sdcpb.DataServer_SubscribeServer) error {

--- a/pkg/utils/converter.go
+++ b/pkg/utils/converter.go
@@ -272,8 +272,13 @@ func (c *Converter) ExpandContainerValue(ctx context.Context, p *sdcpb.Path, jv 
 				np := proto.Clone(p).(*sdcpb.Path)
 				np.Elem = append(np.Elem, &sdcpb.PathElem{Name: item.Name})
 
-				list := []*sdcpb.TypedValue{}
+				se := &sdcpb.SchemaElem{
+					Schema: &sdcpb.SchemaElem_Leaflist{
+						Leaflist: item,
+					},
+				}
 
+				list := []*sdcpb.TypedValue{}
 				// iterate through the elements
 				// ATTENTION: assuming its all strings
 				// add them to the Leaflist value
@@ -285,7 +290,11 @@ func (c *Converter) ExpandContainerValue(ctx context.Context, p *sdcpb.Path, jv 
 								StringVal: fmt.Sprintf("%v", e),
 							},
 						}
-						list = append(list, tv)
+						tvYangType, err := TypedValueToYANGType(tv, se)
+						if err != nil {
+							return nil, err
+						}
+						list = append(list, tvYangType)
 					}
 				default:
 					return nil, fmt.Errorf("leaflist %s expects array as input, but %v of type %v was given", np.String(), x, reflect.TypeOf(x).Name())


### PR DESCRIPTION
validateLeafListValue() called validateLeafTypeValue() with the schema type of the LeafList values, but handed in the ScalarArray instead of iterating over it and checking value by value