### PR TITLE
Bug: SchemaIndex.Retrieve() deadlock

### DIFF
--- a/pkg/tree/schema_index.go
+++ b/pkg/tree/schema_index.go
@@ -10,91 +10,61 @@ import (
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
 )
 
+type schemaIndexEntry struct {
+	schemaRsp *sdcpb.GetSchemaResponse
+	err       error
+	mu        sync.Mutex
+	ready     bool
+}
+
+func NewSchemaIndexEntry(schemaRsp *sdcpb.GetSchemaResponse, err error) *schemaIndexEntry {
+	sie := &schemaIndexEntry{
+		schemaRsp: schemaRsp,
+		err:       err,
+		mu:        sync.Mutex{},
+	}
+	return sie
+}
+
+func (s *schemaIndexEntry) Get() (*sdcpb.GetSchemaResponse, error) {
+	return s.schemaRsp, s.err
+}
+
 type schemaIndex struct {
-	index        map[string]*sdcpb.GetSchemaResponse
-	indexMutex   sync.RWMutex
-	ongoing      map[string]*sync.Cond
-	ongoingMutex sync.Mutex
-	scb          SchemaClient.SchemaClientBound
+	index      sync.Map // string -> schemaIndexEntry
+	indexMutex sync.RWMutex
+	scb        SchemaClient.SchemaClientBound
 }
 
 func newSchemaIndex(scb SchemaClient.SchemaClientBound) *schemaIndex {
 	si := &schemaIndex{
-		index:   map[string]*sdcpb.GetSchemaResponse{},
-		ongoing: map[string]*sync.Cond{},
-		scb:     scb,
+		index: sync.Map{},
+		scb:   scb,
 	}
 	return si
 }
 
-func (si *schemaIndex) retrieveCache(k string) (*sdcpb.GetSchemaResponse, bool) {
-	si.indexMutex.RLock()
-	defer si.indexMutex.RUnlock()
-	val, exists := si.index[k]
-	return val, exists
-}
-
-// retrieveOrCreateOngoingCond retrieve the sync.Cond from the map. If it does not exist, it is being created.
-// the bool indicates if the sync.Cond is new or an existing entry in the map
-func (si *schemaIndex) retrieveOrCreateOngoingCond(k string) (*sync.Cond, bool) {
-	// lets lock the ongoing map
-	si.ongoingMutex.Lock()
-	defer si.ongoingMutex.Unlock()
-	cond, exists := si.ongoing[k]
-	// if k does not exist we need to add a Condition and query the schemaserver
-	if !exists {
-		cond = sync.NewCond(&sync.Mutex{})
-		si.ongoing[k] = cond
-	}
-	return cond, exists
-}
-
 func (si *schemaIndex) Retrieve(ctx context.Context, path *sdcpb.Path) (*sdcpb.GetSchemaResponse, error) {
-
 	// convert the path into a keyless path, for schema index lookups.
 	keylessPathSlice := utils.ToStrings(path, false, true)
 	keylessPath := strings.Join(keylessPathSlice, PATHSEP)
 
-	val, exists := si.retrieveCache(keylessPath)
-	if exists {
-		return val, nil
-	}
-	// does not exist in index yet
+	entryAny, loaded := si.index.LoadOrStore(keylessPath, NewSchemaIndexEntry(nil, nil))
+	entry := entryAny.(*schemaIndexEntry)
 
-	// lets lock the ongoing map
-	cond, existed := si.retrieveOrCreateOngoingCond(keylessPath)
-	defer cond.Broadcast()
+	// Lock the entry to prevent race conditions
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
 
 	// if it existed, some other goroutine is already fetching the schema
-	if existed {
-		cond.L.Lock()
-		defer cond.L.Unlock()
-
-		loop := true
-		// there is already a request ongoing, lets wait for it and then grab it from the cache
-		for loop {
-			cond.Wait()
-			val, exists = si.retrieveCache(keylessPath)
-			loop = !exists
-		}
-
-		return val, nil
+	if loaded && entry.ready {
+		return entry.schemaRsp, entry.err
 	}
 
-	// if schema wasn't found in index, go and fetch it
-	schemaRsp, err := si.scb.GetSchema(ctx, path)
-	if err != nil {
-		return nil, err
-	}
+	schema, err := si.scb.GetSchema(ctx, path)
+	entry.schemaRsp = schema
+	entry.err = err
+	entry.ready = true
 
-	si.indexMutex.Lock()
-	// store the schema in the lookup index
-	si.index[keylessPath] = schemaRsp
-	si.indexMutex.Unlock()
-
-	si.ongoingMutex.Lock()
-	delete(si.ongoing, keylessPath)
-	si.ongoingMutex.Unlock()
-
-	return schemaRsp, nil
+	return entry.Get()
 }


### PR DESCRIPTION
In certain cases the condition.Broadcast would be called before the condition.Wait(). The waiting goroutine would wait forever. So we're getting rid of this overly complicated construct.