### PR TITLE
added configuration parameters for validation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Cache                     *CacheConfig                    `yaml:"cache,omitempty" json:"cache,omitempty"`
 	Prometheus                *PromConfig                     `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
 	DefaultTransactionTimeout time.Duration                   `yaml:"transaction-timeout,omitempty" json:"transaction-timeout,omitempty"`
+	Validation                *Validation                     `yaml:"validation,omitempty" json:"validation,omitempty"`
 }
 
 type TLS struct {
@@ -47,6 +48,8 @@ type TLS struct {
 	Key        string `yaml:"key,omitempty" json:"key,omitempty"`
 	SkipVerify bool   `yaml:"skip-verify,omitempty" json:"skip-verify,omitempty"`
 }
+
+var LoadedConfig *Config
 
 func New(file string) (*Config, error) {
 	c := new(Config)
@@ -62,7 +65,13 @@ func New(file string) (*Config, error) {
 		}
 	}
 	err := c.validateSetDefaults()
-	return c, err
+	if err != nil {
+		return nil, err
+	}
+
+	LoadedConfig = c
+
+	return c, nil
 }
 
 func (c *Config) validateSetDefaults() error {
@@ -128,6 +137,14 @@ func (c *Config) validateSetDefaults() error {
 	if c.DefaultTransactionTimeout == 0 {
 		c.DefaultTransactionTimeout = 5 * time.Minute
 	}
+
+	if c.Validation == nil {
+		c.Validation = &Validation{}
+	}
+	if err = c.Validation.validateSetDefaults(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1,0 +1,37 @@
+package config
+
+type Validation struct {
+	DisabledValidators []Validator `yaml:"disabled-validators,omitempty" json:"disabled-validators,omitempty"`
+	enabledMap         map[Validator]bool
+}
+
+type Validator string
+
+const (
+	Mandatory               Validator = "mandatory"
+	Leafref                 Validator = "leafref"
+	LeafrefMinMaxAttributes Validator = "leafref-min-max-attributes"
+	Pattern                 Validator = "pattern"
+	MustStatements          Validator = "must-statements"
+	Length                  Validator = "length"
+	Range                   Validator = "range"
+	MaxElements             Validator = "max-elements"
+)
+
+var AvailableValidators = [...]Validator{Mandatory, Leafref, LeafrefMinMaxAttributes, Pattern, MustStatements, Length, Range, MaxElements}
+
+func (v *Validation) IsEnabled(validator Validator) bool {
+	return v.enabledMap[validator]
+}
+
+func (v *Validation) validateSetDefaults() error {
+	// Generate enabled map
+	v.enabledMap = make(map[Validator]bool, len(AvailableValidators))
+	for _, validator := range AvailableValidators {
+		v.enabledMap[validator] = true
+	}
+	for _, validator := range v.DisabledValidators {
+		v.enabledMap[Validator(validator)] = false
+	}
+	return nil
+}

--- a/pkg/tree/sharedEntryAttributes.go
+++ b/pkg/tree/sharedEntryAttributes.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/sdcio/data-server/pkg/cache"
+	"github.com/sdcio/data-server/pkg/config"
 	"github.com/sdcio/data-server/pkg/tree/importer"
 	"github.com/sdcio/data-server/pkg/types"
 	"github.com/sdcio/data-server/pkg/utils"
@@ -846,14 +847,28 @@ func (s *sharedEntryAttributes) Validate(ctx context.Context, resultChan chan<- 
 
 	// validate the mandatory statement on this entry
 	if s.remainsToExist() {
-		s.validateMandatory(ctx, resultChan)
-		s.validateLeafRefs(ctx, resultChan)
-		s.validateLeafListMinMaxAttributes(resultChan)
-		s.validatePattern(resultChan)
-		s.validateMustStatements(ctx, resultChan)
-		s.validateLength(resultChan)
-		s.validateRange(resultChan)
-		// s.validateMaxElements(errChan)   // TODO
+		for _, validator := range config.AvailableValidators {
+			if config.LoadedConfig.Validation.IsEnabled(validator) {
+				switch validator {
+				case config.Mandatory:
+					s.validateMandatory(ctx, resultChan)
+				case config.Leafref:
+					s.validateLeafRefs(ctx, resultChan)
+				case config.LeafrefMinMaxAttributes:
+					s.validateLeafListMinMaxAttributes(resultChan)
+				case config.Pattern:
+					s.validatePattern(resultChan)
+				case config.MustStatements:
+					s.validateMustStatements(ctx, resultChan)
+				case config.Length:
+					s.validateLength(resultChan)
+				case config.Range:
+					s.validateRange(resultChan)
+					//case config.MaxElements: //TODO
+					//	s.validateMaxElements(resultChan)
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This is a quick implementation of a way to disable validators based on the data-server.yaml config file to unblock other users. A refactoring of the validation logic is planned.

Adding the following lines to the root level of the data-server.yaml file will disable all validators:
```yaml
validation:
  disabled-validators:
    - mandatory
    - leafref
    - leafref-min-max-attributes
    - pattern
    - must-statements
    - length
    - range
#    - max-elements
```