### PR TITLE
fix leafref-min-max-attributes json name and must-statement in sample

### DIFF
--- a/data-server.yaml
+++ b/data-server.yaml
@@ -197,7 +197,7 @@ validation-defaults:
     leafref: false
     leafref-min-max-attributes: false
     pattern: false
-    must-statements: false
+    must-statement: false
     length: false
     range: false
     max-elements: false # Not yet implemented

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -8,7 +8,7 @@ type Validation struct {
 type Validators struct {
 	Mandatory               bool `yaml:"mandatory,omitempty" json:"mandatory,omitempty"`
 	Leafref                 bool `yaml:"leafref,omitempty" json:"leafref,omitempty"`
-	LeafrefMinMaxAttributes bool `yaml:"leafref-min-max,omitempty" json:"leafref-min-max,omitempty"`
+	LeafrefMinMaxAttributes bool `yaml:"leafref-min-max-attributes,omitempty" json:"leafref-min-max,omitempty"`
 	Pattern                 bool `yaml:"pattern,omitempty" json:"pattern,omitempty"`
 	MustStatement           bool `yaml:"must-statement,omitempty" json:"must-statement,omitempty"`
 	Length                  bool `yaml:"length,omitempty" json:"length,omitempty"`


### PR DESCRIPTION
This minor fix alligns the naming of the validator configuration parameters to be consistent and equal to the sample data-server.yaml file.