### PR TITLE
Fixing the unintended deletion of key attributes

### DIFF
--- a/pkg/tree/entry_test.go
+++ b/pkg/tree/entry_test.go
@@ -340,7 +340,7 @@ func Test_Entry_Three(t *testing.T) {
 		highPri := LeafEntriesToUpdates(highPriLe)
 
 		// diff the result with the expected
-		if diff := testhelper.DiffUpdates([]*types.Update{n1, n2}, highPri); diff != "" {
+		if diff := testhelper.DiffUpdates([]*types.Update{n1, n2, u0, u1_1, u2_1}, highPri); diff != "" {
 			t.Errorf("root.GetByOwner() mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -374,11 +374,11 @@ func Test_Entry_Four(t *testing.T) {
 	u4 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "13", "description"}, desc3, prio50, owner1, ts1)
 	u4_1 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "13", "index"}, testhelper.GetUIntTvProto(13), prio50, owner1, ts1)
 
-	u1o2_0 := types.NewUpdate([]string{"interface", "ethernet-1/1", "name"}, testhelper.GetStringTvProto("ethernet-1/1"), prio55, owner2, ts1)
+	// u1o2_0 := types.NewUpdate([]string{"interface", "ethernet-1/1", "name"}, testhelper.GetStringTvProto("ethernet-1/1"), prio55, owner2, ts1)
 	u1o2 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "10", "description"}, desc3, prio55, owner2, ts1)
-	u1o2_1 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "10", "index"}, testhelper.GetUIntTvProto(10), prio55, owner2, ts1)
+	// u1o2_1 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "10", "index"}, testhelper.GetUIntTvProto(10), prio55, owner2, ts1)
 	u2o2 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "11", "description"}, desc3, prio55, owner2, ts1)
-	u2o2_1 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "11", "index"}, testhelper.GetUIntTvProto(11), prio55, owner2, ts1)
+	// u2o2_1 := types.NewUpdate([]string{"interface", "ethernet-1/1", "subinterface", "11", "index"}, testhelper.GetUIntTvProto(11), prio55, owner2, ts1)
 
 	ctx := context.TODO()
 
@@ -461,7 +461,7 @@ func Test_Entry_Four(t *testing.T) {
 		highPri := LeafEntriesToUpdates(highPriLe)
 
 		// diff the result with the expected
-		if diff := testhelper.DiffUpdates([]*types.Update{n1, n2}, highPri); diff != "" {
+		if diff := testhelper.DiffUpdates([]*types.Update{n1, n2, u1o1_0, u1o1_1, u2o1_1}, highPri); diff != "" {
 			t.Errorf("root.GetByOwner() mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -477,7 +477,7 @@ func Test_Entry_Four(t *testing.T) {
 	t.Run("Check the old entries are gone from highest (Only New Or Updated)", func(t *testing.T) {
 		highpri := root.GetHighestPrecedence(true)
 		// diff the result with the expected
-		if diff := testhelper.DiffUpdates([]*types.Update{u1o2_0, n1, n2, u2o2_1, u1o2_1}, highpri.ToUpdateSlice()); diff != "" {
+		if diff := testhelper.DiffUpdates([]*types.Update{u1o1_0, n1, n2, u2o1_1, u1o1_1}, highpri.ToUpdateSlice()); diff != "" {
 			t.Errorf("root.GetHighestPrecedence() mismatch (-want +got):\n%s", diff)
 		}
 	})

--- a/pkg/tree/leaf_entry.go
+++ b/pkg/tree/leaf_entry.go
@@ -63,6 +63,10 @@ func (l *LeafEntry) MarkNew() {
 	l.IsNew = true
 }
 
+func (l *LeafEntry) RemoveDeleteFlag() {
+	l.Delete = false
+}
+
 func (l *LeafEntry) GetDeleteFlag() bool {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/pkg/tree/sharedEntryAttributes.go
+++ b/pkg/tree/sharedEntryAttributes.go
@@ -222,6 +222,7 @@ func (s *sharedEntryAttributes) checkAndCreateKeysAsLeafs(ctx context.Context, i
 				var result []*LeafEntry
 				lvs := child.GetByOwner(intentName, result)
 				if len(lvs) > 0 {
+					lvs[0].RemoveDeleteFlag()
 					continue
 				}
 			}
@@ -1608,7 +1609,7 @@ func (s *sharedEntryAttributes) TreeExport(owner string) ([]*tree_persist.TreeEl
 func (s *sharedEntryAttributes) BlameConfig(includeDefaults bool) (*sdcpb.BlameTreeElement, error) {
 	name := s.pathElemName
 	if s.GetLevel() == 0 {
-		name = fmt.Sprintf("root")
+		name = "root"
 	}
 	result := sdcpb.NewBlameTreeElement(name)
 


### PR DESCRIPTION
The deletion occures after importing the already committed intent from the cache in tree_proto format. The Intent content in the tree was marked as delete, as expected, but then re-applying the new intent content, the key attributes where just checked for existence, but the delete flag was not reset.