### PR TITLE
escape non-metacharacters (XML spec)

### DIFF
--- a/pkg/utils/leaf_convert_test.go
+++ b/pkg/utils/leaf_convert_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestXMLRegexConvert(t *testing.T) {
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "anchors become literals",
+			in:   `^\d+$`,
+			want: `\^\d+\$`,
+		},
+		{
+			name: "already-escaped anchors stay escaped",
+			in:   `foo\$bar`,
+			want: `foo\$bar`,
+		},
+		{
+			name: "caret in char class is left alone, dollar is escaped",
+			in:   `[^\w]+$`,
+			want: `[^\w]+\$`,
+		},
+		{
+			name: "caret later inside char class is escaped",
+			in:   `[a^b]`,
+			want: `[a\^b]`,
+		},
+		{
+			name: "caret escaped inside char class is escaped",
+			in:   `[\^]`,
+			want: `[\^]`,
+		},
+		{
+			name: "caret in char class multiple times, dollar is escaped",
+			in:   `[^a^b]`,
+			want: `[^a\^b]`,
+		},
+		{
+			name: "anchors preceded by a single back-slash stay escaped",
+			in:   `\^test\$`,
+			want: `\^test\$`,
+		},
+		{
+			name: "empty string",
+			in:   ``,
+			want: ``,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := XMLRegexConvert(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("XMLRegexConvert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The set of metacharacters is not the same between XML schema and perl/python/go Regular Expressions.

The set of metacharacters for XML schema is: `.\?*+{}()[]` ([reference](https://www.w3.org/TR/xmlschema-2/#dt-metac))
the set of metacharacters defined in go is: `\.+*?()|[]{}^$` (go/libexec/src/regexp/regexp.go:714)

To maintain compatibility, we need to force escape the difference in these two sets (`^` and `$`).
`^` is a bit special as it is a valid metacharacter as the first char after the opening of a character set (`[^...`) so we make sure not to escape it in this position