### PR TITLE
Reorganization of gNMI updates and deletes requests for Cisco XRd devices

### DIFF
--- a/pkg/datastore/target/gnmi.go
+++ b/pkg/datastore/target/gnmi.go
@@ -158,6 +158,8 @@ func (t *gnmiTarget) Get(ctx context.Context, req *sdcpb.GetDataRequest) (*sdcpb
 	return schemaRsp, nil
 }
 
+var nsMap = make(map[string]string)
+
 func (t *gnmiTarget) Set(ctx context.Context, source TargetSource) (*sdcpb.SetDataResponse, error) {
 	var upds []*sdcpb.Update
 	var deletes []*sdcpb.Path
@@ -193,11 +195,91 @@ func (t *gnmiTarget) Set(ctx context.Context, source TargetSource) (*sdcpb.SetDa
 			return nil, err
 		}
 		if jsonData != nil {
-			jsonBytes, err := json.Marshal(jsonData)
-			if err != nil {
-				return nil, err
+			upds = []*sdcpb.Update{}
+			for key, value := range jsonData.(map[string]any) {
+				keyParts := strings.Split(key, ":")
+				rootNamespace := ""
+				rootNodeName := ""
+				if len(keyParts) == 2 {
+					rootNamespace = keyParts[0]
+					rootNodeName = keyParts[1]
+				}
+
+				updsPerNs := make(map[string]map[string]any)
+
+				// check second level of data to distinguish namespaces
+				for k, v := range value.(map[string]any) {
+					kP := strings.Split(k, ":")
+					var leafNamespace string
+					var leafNodeName string
+					if len(kP) == 2 {
+						leafNodeName = kP[1]
+						if len(kP) == 2 && kP[0] != rootNamespace {
+							// diverged namespace
+							leafNamespace = kP[0]
+							nsMap[rootNodeName+"/"+leafNodeName] = rootNamespace
+						} else {
+							// root namespace
+							leafNamespace = rootNamespace
+						}
+					} else {
+						leafNodeName = kP[0]
+						leafNamespace = rootNamespace
+						nsMap[rootNodeName] = rootNamespace
+					}
+					_, found := updsPerNs[leafNamespace]
+					if !found {
+						updsPerNs[leafNamespace] = make(map[string]any)
+					}
+					updsPerNs[leafNamespace][leafNodeName] = v
+				}
+
+				for k, v := range updsPerNs {
+					updPath := &sdcpb.Path{Origin: k}
+
+					updKey := k + ":" + rootNodeName
+
+					singleUpd := map[string]any{}
+					singleUpd[updKey] = v
+
+					singleUpdBytes, err := json.Marshal(singleUpd)
+					if err != nil {
+						return nil, err
+					}
+					updValue := &sdcpb.TypedValue{
+						Value: &sdcpb.TypedValue_JsonIetfVal{
+							JsonIetfVal: singleUpdBytes,
+						},
+					}
+
+					upds = append(upds, &sdcpb.Update{
+						Path:  updPath,
+						Value: updValue,
+					})
+				}
 			}
-			upds = []*sdcpb.Update{{Path: &sdcpb.Path{}, Value: &sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonIetfVal{JsonIetfVal: jsonBytes}}}}
+		}
+
+		for _, delete := range deletes {
+			if len(delete.Elem) > 0 {
+				completePath := ""
+				found := false
+				var mostSpecificOrigin string
+				for _, elem := range delete.Elem {
+					if completePath != "" {
+						completePath += "/"
+					}
+					completePath += elem.Name
+					origin, f := nsMap[completePath]
+					if f {
+						found = true
+						mostSpecificOrigin = origin
+					}
+				}
+				if found {
+					delete.Origin = mostSpecificOrigin
+				}
+			}
 		}
 
 	case "proto":
@@ -368,7 +450,7 @@ func (t *gnmiTarget) getSync(ctx context.Context, gnmiSync *config.SyncProtocol,
 	req := &sdcpb.GetDataRequest{
 		Name:     gnmiSync.Name,
 		Path:     paths,
-		DataType: sdcpb.DataType_CONFIG,
+		DataType: sdcpb.DataType_ALL,
 		Encoding: sdcpb.Encoding(sdcpbEncoding(gnmiSync.Encoding)),
 	}
 

--- a/pkg/tree/validation_entry_leafref.go
+++ b/pkg/tree/validation_entry_leafref.go
@@ -216,7 +216,7 @@ func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan
 	entry, err := s.NavigateLeafRef(ctx)
 	if err != nil || len(entry) == 0 {
 		// check if the OptionalInstance (!require-instances [https://datatracker.ietf.org/doc/html/rfc7950#section-9.9.3])
-		if s.schema.GetField().GetType().GetOptionalInstance() {
+		if !s.schema.GetField().IsMandatory {
 			generateOptionalWarning(ctx, s, lref, resultChan)
 			return
 		}

--- a/pkg/utils/converter.go
+++ b/pkg/utils/converter.go
@@ -473,7 +473,13 @@ func convertStringToTv(schemaType *sdcpb.SchemaLeafType, v string, ts uint64) (*
 	case "boolean":
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			return nil, err
+			if strings.Contains(strings.ToLower(v), "true") {
+				b = true
+			} else if strings.Contains(strings.ToLower(v), "false") {
+				b = false
+			} else {
+				return nil, err
+			}
 		}
 		return &sdcpb.TypedValue{
 			Timestamp: ts,


### PR DESCRIPTION
I encountered an issue when trying the project with Cisco XRd devices, and that patch resolves the problem.

### Schema validation and parsing
In some cases, the device returns the strings `"true"` or `"false"` instead of the boolean type, and that fixes the problem
The `GetOptionalInstance()` is not working in some contexts, while the appropriate flag (present on the same structure) seems to be `IsMandatory`.

### Sending appropriate `gNMI update` and `delete` requests
The current implementation doesn't take into account the presence of schema in different namespaces, needed in the Cisco environment.
So, there is these needs:
- separate updates in different requests, one for each namespace (cannot update resources in several namespaces with the same request)
- add the namespace prefix (in the form `namespace:path`) instead of using a "blank" path and only a "value"

The proposed implementation is tailored to my environment, and has some more work to do to be ready for every scenario. I leave the code so that it can be taken to understand better the needs:
- I use an in-memory map that is not persisted, and might generate some problems in case of component crash
- probably (pretty sure) I have implemented it in the wrong place: I used `json_ietf`, so I put here my code, but probably it should be moved somewhere else
- in the `delete` scenario I used an approach that can understand even path differentiations in subpaths of any grade, while in the `update` one it can understand only the first and second elements of the path (e.g. `router/static` belongs to the module `static-routing`, while `router/ospf` belongs to `dynamic-routing`, so the respective requests should be directed to `static-routing:router/static` and `dynamic-routing:router/ospf`)