### PR TITLE
Fixes for NETCONF key ordering and leaflists

### DIFF
--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -177,6 +177,24 @@ func (s *Sync) validateSetDefaults() error {
 	if s.WriteWorkers <= 0 {
 		s.WriteWorkers = defaultWriteWorkers
 	}
+
+	var errs []error
+	for _, sp := range s.Config {
+		err := sp.validateSetDefaults()
+		errs = append(errs, err)
+	}
+	err := errors.Join(errs...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *SyncProtocol) validateSetDefaults() error {
+	if s.Interval <= 0 {
+		s.Interval = defaultSyncInterval
+	}
 	return nil
 }
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -32,6 +32,7 @@ const (
 	defaultCacheDir           = "./cached/caches"
 	defaultWriteWorkers       = 16
 	defaultTimeout            = 30 * time.Second
+	defaultSyncInterval       = 30 * time.Second
 
 	defaultSchemaStorePath = "./schema-dir"
 )

--- a/pkg/datastore/target/netconf/xml2SchemapbAdapter_test.go
+++ b/pkg/datastore/target/netconf/xml2SchemapbAdapter_test.go
@@ -153,6 +153,198 @@ func TestXML2sdcpbConfigAdapter_Transform(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "leaflist string",
+			args: args{
+				ctx: context.TODO(),
+				doc: func() *etree.Document {
+					doc := etree.NewDocument()
+					data := doc.CreateElement("data")
+					container := data.CreateElement("leaf-list-container")
+					container.CreateElement("item").SetText("item-0")
+					container.CreateElement("item").SetText("item-1")
+					return doc
+				}(),
+			},
+			getXML2sdcpbConfigAdapter: func(ctrl *gomock.Controller, t *testing.T) *XML2sdcpbConfigAdapter {
+
+				var expectedPath string
+
+				schemaClientMock := mockschemaclientbound.NewMockSchemaClientBound(ctrl)
+				counter := 0
+				schemaClientMock.EXPECT().GetSchemaSdcpbPath(context.TODO(), gomock.Any()).AnyTimes().DoAndReturn(
+					func(ctx context.Context, path *sdcpb.Path) (*sdcpb.GetSchemaResponse, error) {
+						lls := &sdcpb.LeafListSchema{
+							Name: "item",
+							Type: &sdcpb.SchemaLeafType{
+								Type: "string",
+							},
+						}
+						selem := &sdcpb.SchemaElem{}
+						switch counter {
+						case 0:
+							selem.Schema = &sdcpb.SchemaElem_Container{
+								Container: &sdcpb.ContainerSchema{
+									Name: "leaf-list-container",
+									Leaflists: []*sdcpb.LeafListSchema{
+										lls,
+									},
+								},
+							}
+							expectedPath = "leaf-list-container"
+						case 1, 2:
+							selem.Schema = &sdcpb.SchemaElem_Leaflist{
+								Leaflist: lls,
+							}
+							expectedPath = "leaf-list-container/item"
+						}
+						// check for the right input
+						if rp := utils.ToXPath(path, false); rp != expectedPath {
+							t.Errorf("getSchema expected path %s but got %s", expectedPath, rp)
+						}
+
+						counter++
+						return &sdcpb.GetSchemaResponse{
+							Schema: selem,
+						}, nil
+					},
+				)
+				return NewXML2sdcpbConfigAdapter(schemaClientMock)
+			},
+			want: []*sdcpb.Notification{
+				{
+					Update: []*sdcpb.Update{
+						{
+							Path: &sdcpb.Path{
+								Elem: []*sdcpb.PathElem{
+									{
+										Name: "leaf-list-container",
+									},
+									{
+										Name: "item",
+									},
+								},
+							},
+							Value: &sdcpb.TypedValue{
+								Value: &sdcpb.TypedValue_LeaflistVal{
+									LeaflistVal: &sdcpb.ScalarArray{
+										Element: []*sdcpb.TypedValue{
+											{
+												Value: &sdcpb.TypedValue_StringVal{
+													StringVal: "item-0",
+												},
+											},
+											{
+												Value: &sdcpb.TypedValue_StringVal{
+													StringVal: "item-1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "leaflist int32",
+			args: args{
+				ctx: context.TODO(),
+				doc: func() *etree.Document {
+					doc := etree.NewDocument()
+					data := doc.CreateElement("data")
+					container := data.CreateElement("leaf-list-container")
+					container.CreateElement("item").SetText("0")
+					container.CreateElement("item").SetText("1")
+					return doc
+				}(),
+			},
+			getXML2sdcpbConfigAdapter: func(ctrl *gomock.Controller, t *testing.T) *XML2sdcpbConfigAdapter {
+
+				var expectedPath string
+
+				schemaClientMock := mockschemaclientbound.NewMockSchemaClientBound(ctrl)
+				counter := 0
+				schemaClientMock.EXPECT().GetSchemaSdcpbPath(context.TODO(), gomock.Any()).AnyTimes().DoAndReturn(
+					func(ctx context.Context, path *sdcpb.Path) (*sdcpb.GetSchemaResponse, error) {
+						lls := &sdcpb.LeafListSchema{
+							Name: "item",
+							Type: &sdcpb.SchemaLeafType{
+								Type: "int32",
+							},
+						}
+						selem := &sdcpb.SchemaElem{}
+						switch counter {
+						case 0:
+							selem.Schema = &sdcpb.SchemaElem_Container{
+								Container: &sdcpb.ContainerSchema{
+									Name: "leaf-list-container",
+									Leaflists: []*sdcpb.LeafListSchema{
+										lls,
+									},
+								},
+							}
+							expectedPath = "leaf-list-container"
+						case 1, 2:
+							selem.Schema = &sdcpb.SchemaElem_Leaflist{
+								Leaflist: lls,
+							}
+							expectedPath = "leaf-list-container/item"
+						}
+						// check for the right input
+						if rp := utils.ToXPath(path, false); rp != expectedPath {
+							t.Errorf("getSchema expected path %s but got %s", expectedPath, rp)
+						}
+
+						counter++
+						return &sdcpb.GetSchemaResponse{
+							Schema: selem,
+						}, nil
+					},
+				)
+				return NewXML2sdcpbConfigAdapter(schemaClientMock)
+			},
+			want: []*sdcpb.Notification{
+				{
+					Update: []*sdcpb.Update{
+						{
+							Path: &sdcpb.Path{
+								Elem: []*sdcpb.PathElem{
+									{
+										Name: "leaf-list-container",
+									},
+									{
+										Name: "item",
+									},
+								},
+							},
+							Value: &sdcpb.TypedValue{
+								Value: &sdcpb.TypedValue_LeaflistVal{
+									LeaflistVal: &sdcpb.ScalarArray{
+										Element: []*sdcpb.TypedValue{
+											{
+												Value: &sdcpb.TypedValue_IntVal{
+													IntVal: 0,
+												},
+											},
+											{
+												Value: &sdcpb.TypedValue_IntVal{
+													IntVal: 1,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/datastore/transaction_rpc.go
+++ b/pkg/datastore/transaction_rpc.go
@@ -140,7 +140,7 @@ func (d *Datastore) LoadAllButRunningIntents(ctx context.Context, root *tree.Roo
 			intentNames = append(intentNames, intent.GetIntentName())
 			log.Debugf("adding intent %s to tree", intent.GetIntentName())
 			protoLoader := treeproto.NewProtoTreeImporter(intent.GetRoot())
-			log.Tracef(intent.String())
+			log.Tracef("%s", intent.String())
 			err := root.ImportConfig(ctx, nil, protoLoader, intent.GetIntentName(), intent.GetPriority(), treetypes.NewUpdateInsertFlags())
 			if err != nil {
 				return nil, err

--- a/pkg/tree/xml.go
+++ b/pkg/tree/xml.go
@@ -285,7 +285,8 @@ func xmlAddKeyElements(s Entry, parent *etree.Element) {
 			// and finally we create the key elements in schema order
 			keyElem := etree.NewElement(schemaKeys[i])
 			keyElem.SetText(treeElem.PathName())
-			xmlAddNamespaceConditional(parentSchema.GetParent(), parentSchema, keyElem, true)
+			//TODO: Do we need to add namespaces?
+			// xmlAddNamespaceConditional(parentSchema, parentSchema.GetParent(), keyElem, true)
 			parent.InsertChildAt(0, keyElem) // we go backwards, so always add to front of parent
 			treeElem = treeElem.GetParent()
 		}

--- a/pkg/tree/xml.go
+++ b/pkg/tree/xml.go
@@ -270,9 +270,13 @@ func xmlAddKeyElements(s Entry, parent *etree.Element) {
 		// skip if the element already exists
 		existingElem := parent.SelectElement(schemaKeys[i])
 		if existingElem == nil {
-			// and finally we create the patheleme key attributes
-			parent.CreateElement(schemaKeys[i]).SetText(treeElem.PathName())
+			// and finally we create the key elements in schema order
+			keyElem := etree.NewElement(schemaKeys[i])
+			keyElem.SetText(treeElem.PathName())
+			xmlAddNamespaceConditional(parentSchema.GetParent(), parentSchema, keyElem, true)
+			parent.InsertChildAt(0, keyElem) // we go backwards, so always add to front of parent
 			treeElem = treeElem.GetParent()
 		}
 	}
+
 }

--- a/pkg/tree/xml.go
+++ b/pkg/tree/xml.go
@@ -113,8 +113,18 @@ func (s *sharedEntryAttributes) toXmlInternal(parent *etree.Element, onlyNewOrUp
 				overallDoAdd = doAdd || overallDoAdd
 				// add the child only if doAdd is true
 				if doAdd {
-					xmlAddKeyElements(child, newElem)
-					// add all the key elements if they do not already exist
+					// Are we performing a replace?
+					replaceAttr := newElem.SelectAttr("nc:operation")
+					if replaceAttr != nil && replaceAttr.Value == string(utils.XMLOperationReplace) {
+						// If we are replacing, we need to have all child values added to the xml tree else they will be removed from the device
+						err := xmlAddAllChildValues(child, newElem, honorNamespace, operationWithNamespace, useOperationRemove)
+						if err != nil {
+							return false, err
+						}
+					} else {
+						// if we are not performing a replace, add all the key elements if they do not already exist
+						xmlAddKeyElements(child, newElem)
+					}
 					parent.AddChild(newElem)
 				}
 			}
@@ -179,6 +189,7 @@ func (s *sharedEntryAttributes) toXmlInternal(parent *etree.Element, onlyNewOrUp
 				if !exists {
 					return false, fmt.Errorf("child %s does not exist for %s", k, strings.Join(s.Path(), "/"))
 				}
+				// TODO: Do we also need to xmlAddAllChildValues here too?
 				doAdd, err := child.toXmlInternal(newElem, onlyNewOrUpdated, honorNamespace, operationWithNamespace, useOperationRemove)
 				if err != nil {
 					return false, err
@@ -261,6 +272,7 @@ func xmlAddKeyElements(s Entry, parent *etree.Element) {
 	// retrieve the parent schema, we need to extract the key names
 	// values are the tree level names
 	parentSchema, levelsUp := s.GetFirstAncestorWithSchema()
+
 	// from the parent we get the keys as slice
 	schemaKeys := parentSchema.GetSchemaKeys()
 	var treeElem Entry = s
@@ -278,5 +290,13 @@ func xmlAddKeyElements(s Entry, parent *etree.Element) {
 			treeElem = treeElem.GetParent()
 		}
 	}
+}
 
+func xmlAddAllChildValues(s Entry, parent *etree.Element, honorNamespace bool, operationWithNamespace bool, useOperationRemove bool) error {
+	parent.Child = make([]etree.Token, 0)
+	_, err := s.toXmlInternal(parent, false, honorNamespace, operationWithNamespace, useOperationRemove)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/tree/xml.go
+++ b/pkg/tree/xml.go
@@ -285,8 +285,6 @@ func xmlAddKeyElements(s Entry, parent *etree.Element) {
 			// and finally we create the key elements in schema order
 			keyElem := etree.NewElement(schemaKeys[i])
 			keyElem.SetText(treeElem.PathName())
-			//TODO: Do we need to add namespaces?
-			// xmlAddNamespaceConditional(parentSchema, parentSchema.GetParent(), keyElem, true)
 			parent.InsertChildAt(0, keyElem) // we go backwards, so always add to front of parent
 			treeElem = treeElem.GetParent()
 		}

--- a/pkg/tree/xml_test.go
+++ b/pkg/tree/xml_test.go
@@ -3,6 +3,7 @@ package tree
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -394,6 +395,28 @@ func TestToXMLTable(t *testing.T) {
 				}
 				return expandUpdateFromConfig(ctx, c, converter)
 			},
+		},
+		{
+			name:             "XML - device returns leaflist out of order",
+			onlyNewOrUpdated: true,
+			existingConfig: func(ctx context.Context, converter *utils.Converter) ([]*sdcpb.Update, error) {
+				c := config1()
+				return expandUpdateFromConfig(ctx, c, converter)
+			},
+			runningConfig: func(ctx context.Context, converter *utils.Converter) ([]*sdcpb.Update, error) {
+				c := config1()
+				slices.Reverse(c.Leaflist.Entry)
+				upds, err := expandUpdateFromConfig(ctx, c, converter)
+				if err != nil {
+					return nil, err
+				}
+				return upds, nil
+			},
+			expected: ``,
+			honorNamespace:         true,
+			operationWithNamespace: true,
+			useOperationRemove:     true,
+			newConfig: nil,
 		},
 	}
 

--- a/pkg/tree/xml_test.go
+++ b/pkg/tree/xml_test.go
@@ -500,6 +500,7 @@ func TestToXMLTable(t *testing.T) {
 			}
 
 			// Make sure the attributes are sorted, otherwise the comparison is an issue
+			//TODO: Follow order of schema
 			utils.XmlRecursiveSortElementsByTagName(&xmlDoc.Element)
 
 			xmlDoc.Indent(2)

--- a/pkg/utils/value.go
+++ b/pkg/utils/value.go
@@ -16,7 +16,9 @@ package utils
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -393,8 +395,18 @@ func EqualTypedValues(v1, v2 *sdcpb.TypedValue) bool {
 			if len(v1.LeaflistVal.GetElement()) != len(v2.LeaflistVal.GetElement()) {
 				return false
 			}
-			for i := range v1.LeaflistVal.GetElement() {
-				if !EqualTypedValues(v1.LeaflistVal.Element[i], v2.LeaflistVal.Element[i]) {
+
+			ll1 := slices.Clone(v1.LeaflistVal.GetElement())
+			ll2 := slices.Clone(v2.LeaflistVal.GetElement())
+			sf := func(a,b *sdcpb.TypedValue) int {
+				return cmp.Compare(a.ToString(), b.ToString())
+			}
+			slices.SortFunc(ll1, sf)
+			slices.SortFunc(ll2, sf)
+
+
+			for i := range ll1 {
+				if !EqualTypedValues(ll1[i], ll2[i]) {
 					return false
 				}
 			}
@@ -441,7 +453,6 @@ func EqualTypedValues(v1, v2 *sdcpb.TypedValue) bool {
 			return false
 		}
 	}
-	// TODO: Why is this default case to return true??
 	return true
 }
 

--- a/pkg/utils/value.go
+++ b/pkg/utils/value.go
@@ -385,33 +385,32 @@ func EqualTypedValues(v1, v2 *sdcpb.TypedValue) bool {
 		}
 	case *sdcpb.TypedValue_LeaflistVal:
 		switch v2 := v2.GetValue().(type) {
-			case *sdcpb.TypedValue_LeaflistVal:
-				if v1 == nil && v2 == nil {
-					return true
-				}
-				if v1 == nil || v2 == nil {
-					return false
-				}
-				if len(v1.LeaflistVal.GetElement()) != len(v2.LeaflistVal.GetElement()) {
-					return false
-				}
-
-				ll1 := slices.Clone(v1.LeaflistVal.GetElement())
-				ll2 := slices.Clone(v2.LeaflistVal.GetElement())
-				sf := func(a,b *sdcpb.TypedValue) int {
-					return cmp.Compare(a.ToString(), b.ToString())
-				}
-				slices.SortFunc(ll1, sf)
-				slices.SortFunc(ll2, sf)
-
-
-				for i := range ll1 {
-					if !EqualTypedValues(ll1[i], ll2[i]) {
-						return false
-					}
-				}
-			default:
+		case *sdcpb.TypedValue_LeaflistVal:
+			if v1 == nil && v2 == nil {
+				return true
+			}
+			if v1 == nil || v2 == nil {
 				return false
+			}
+			if len(v1.LeaflistVal.GetElement()) != len(v2.LeaflistVal.GetElement()) {
+				return false
+			}
+
+			ll1 := slices.Clone(v1.LeaflistVal.GetElement())
+			ll2 := slices.Clone(v2.LeaflistVal.GetElement())
+			sf := func(a, b *sdcpb.TypedValue) int {
+				return cmp.Compare(a.ToString(), b.ToString())
+			}
+			slices.SortFunc(ll1, sf)
+			slices.SortFunc(ll2, sf)
+
+			for i := range ll1 {
+				if !EqualTypedValues(ll1[i], ll2[i]) {
+					return false
+				}
+			}
+		default:
+			return false
 		}
 	case *sdcpb.TypedValue_ProtoBytes:
 		switch v2 := v2.GetValue().(type) {

--- a/pkg/utils/value.go
+++ b/pkg/utils/value.go
@@ -385,33 +385,33 @@ func EqualTypedValues(v1, v2 *sdcpb.TypedValue) bool {
 		}
 	case *sdcpb.TypedValue_LeaflistVal:
 		switch v2 := v2.GetValue().(type) {
-		case *sdcpb.TypedValue_LeaflistVal:
-			if v1 == nil && v2 == nil {
-				return true
-			}
-			if v1 == nil || v2 == nil {
-				return false
-			}
-			if len(v1.LeaflistVal.GetElement()) != len(v2.LeaflistVal.GetElement()) {
-				return false
-			}
-
-			ll1 := slices.Clone(v1.LeaflistVal.GetElement())
-			ll2 := slices.Clone(v2.LeaflistVal.GetElement())
-			sf := func(a,b *sdcpb.TypedValue) int {
-				return cmp.Compare(a.ToString(), b.ToString())
-			}
-			slices.SortFunc(ll1, sf)
-			slices.SortFunc(ll2, sf)
-
-
-			for i := range ll1 {
-				if !EqualTypedValues(ll1[i], ll2[i]) {
+			case *sdcpb.TypedValue_LeaflistVal:
+				if v1 == nil && v2 == nil {
+					return true
+				}
+				if v1 == nil || v2 == nil {
 					return false
 				}
-			}
-		default:
-			return false
+				if len(v1.LeaflistVal.GetElement()) != len(v2.LeaflistVal.GetElement()) {
+					return false
+				}
+
+				ll1 := slices.Clone(v1.LeaflistVal.GetElement())
+				ll2 := slices.Clone(v2.LeaflistVal.GetElement())
+				sf := func(a,b *sdcpb.TypedValue) int {
+					return cmp.Compare(a.ToString(), b.ToString())
+				}
+				slices.SortFunc(ll1, sf)
+				slices.SortFunc(ll2, sf)
+
+
+				for i := range ll1 {
+					if !EqualTypedValues(ll1[i], ll2[i]) {
+						return false
+					}
+				}
+			default:
+				return false
 		}
 	case *sdcpb.TypedValue_ProtoBytes:
 		switch v2 := v2.GetValue().(type) {

--- a/pkg/utils/value_test.go
+++ b/pkg/utils/value_test.go
@@ -307,6 +307,18 @@ func TestEqualTypedValues(t *testing.T) {
 			),
 			false,
 		},
+		{
+			"leaflist diff elements",
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 2}},
+			),
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 3}},
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 4}},
+			),
+			false,
+		},
 
 		// --- ProtoBytes ---
 		{

--- a/pkg/utils/value_test.go
+++ b/pkg/utils/value_test.go
@@ -1,0 +1,360 @@
+// Copyright 2024 Nokia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestEqualTypedValues(t *testing.T) {
+
+	// helper to build an AnyVal
+	anyVal := func(v []byte) *sdcpb.TypedValue {
+		return &sdcpb.TypedValue{
+			Value: &sdcpb.TypedValue_AnyVal{AnyVal: &anypb.Any{
+				Value: v,
+			}},
+		}
+	}
+
+	// helper to build an IdentityrefVal
+	identVal := func(value string, module string, prefix string) *sdcpb.TypedValue {
+		return &sdcpb.TypedValue{
+			Value: &sdcpb.TypedValue_IdentityrefVal{
+				IdentityrefVal: &sdcpb.IdentityRef{
+					Value:  value,
+					Prefix: prefix,
+					Module: module,
+				},
+			},
+		}
+	}
+
+	// helper to build a DecimalVal
+	decVal := func(digits int64, precision uint32) *sdcpb.TypedValue {
+		return &sdcpb.TypedValue{
+			Value: &sdcpb.TypedValue_DecimalVal{
+				DecimalVal: &sdcpb.Decimal64{
+					Digits:    digits,
+					Precision: precision,
+				},
+			},
+		}
+	}
+
+	// helper to build a LeaflistVal
+	leaflist := func(elems ...*sdcpb.TypedValue) *sdcpb.TypedValue {
+		return &sdcpb.TypedValue{
+			Value: &sdcpb.TypedValue_LeaflistVal{
+				LeaflistVal: &sdcpb.ScalarArray{
+					Element: elems,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		t1   *sdcpb.TypedValue
+		t2   *sdcpb.TypedValue
+		want bool
+	}{
+		// --- nil cases ---
+		{
+			"both nil",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"nil, non-nil",
+			nil,
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BoolVal{BoolVal: true}},
+			false,
+		},
+		{
+			"non-nil, nil",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BoolVal{BoolVal: true}},
+			nil,
+			false,
+		},
+
+		// --- mismatched types ---
+		{
+			"ascii vs bool",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_AsciiVal{AsciiVal: "x"}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BoolVal{BoolVal: true}},
+			false,
+		},
+
+		// --- AnyVal ---
+		{
+			"any equal",
+			anyVal([]byte{1, 2, 3}),
+			anyVal([]byte{1, 2, 3}),
+			true,
+		},
+		{
+			"any diff",
+			anyVal([]byte{1}),
+			anyVal([]byte{2}), false,
+		},
+
+		// --- AsciiVal ---
+		{
+			"ascii equal",
+			&sdcpb.TypedValue{
+				Value:     &sdcpb.TypedValue_AsciiVal{AsciiVal: "foo"},
+			},
+			&sdcpb.TypedValue{
+				Value:     &sdcpb.TypedValue_AsciiVal{AsciiVal: "foo"},
+			}, 
+			true,
+		},
+		{
+			"ascii diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_AsciiVal{AsciiVal: "a"}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_AsciiVal{AsciiVal: "b"}},
+			false,
+		},
+
+		// --- IdentityrefVal ---
+		{
+			"ident equal",
+			identVal("v", "m", "p"),
+			identVal("v", "m", "p"),
+			true,
+		},
+		{
+			"ident diff value",
+			identVal("v1", "m", "p"), 
+			identVal("v2", "m", "p"),
+			false,
+		},
+
+		// --- BoolVal ---
+		{
+			"bool equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BoolVal{BoolVal: true}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BoolVal{BoolVal: true}},
+			true,
+		},
+		{
+			"bool diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BoolVal{BoolVal: true}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BoolVal{BoolVal: false}},
+			false,
+		},
+
+		// --- BytesVal ---
+		{
+			"bytes equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BytesVal{BytesVal: []byte{1, 2}}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BytesVal{BytesVal: []byte{1, 2}}},
+			true,
+		},
+		{
+			"bytes diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BytesVal{BytesVal: []byte{1, 2}}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_BytesVal{BytesVal: []byte{2, 3}}},
+			false,
+		},
+
+		// --- DecimalVal ---
+		{
+			"decimal equal",
+			decVal(123, 2),
+			decVal(123, 2),
+			true, 
+		},
+		{
+			"decimal precision diff",
+			decVal(123, 2),
+			decVal(123, 3),
+			false,
+		},
+		{
+			"decimal digits diff",
+			decVal(123, 2),
+			decVal(321, 2),
+			false,
+		},
+
+		// --- EmptyVal ---
+		{
+			"empty vs empty",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_EmptyVal{}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_EmptyVal{}},
+			true,
+		},
+		{
+			"empty vs non-empty",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_EmptyVal{}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_StringVal{StringVal: "foo"}},
+			false,
+		},
+
+		// --- FloatVal ---
+		{
+			"float equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_FloatVal{FloatVal: 1.23}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_FloatVal{FloatVal: 1.23}},
+			true,
+		},
+		{
+			"float diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_FloatVal{FloatVal: 1.2}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_FloatVal{FloatVal: 2.1}},
+			false,
+		},
+
+		// --- IntVal ---
+		{
+			"int equal pos",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+			true,
+		},
+		{
+			"int equal neg",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: -1}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: -1}},
+			true,
+		},
+		{
+			"int diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 2}},
+			false,
+		},
+
+		// --- JsonIetfVal ---
+		{
+			"json-ietf equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(`{"a":1}`)}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(`{"a":1}`)}},
+			true,
+		},
+		{
+			"json-ietf diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(`{"a":1}`)}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(`{"a":2}`)}},
+			false,
+		},
+
+		// --- JsonVal ---
+		{
+			"json equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonVal{JsonVal: []byte(`{"foo":"bar"}`)}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonVal{JsonVal: []byte(`{"foo":"bar"}`)}},
+			true,
+		},
+		{
+			"json diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonVal{JsonVal: []byte(`{"foo":"bar"}`)}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_JsonVal{JsonVal: []byte(`{"bar":"foo"}`)}},
+			false,
+		},
+
+		// --- LeaflistVal ---
+		{
+			"leaflist equal same order",
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 2}},
+			),
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 2}},
+			),
+			true,
+		},
+		{
+			"leaflist equal diff order",
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 2}},
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+			),
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 2}},
+			),
+			true,
+		},
+		{
+			"leaflist diff length",
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+			),
+			leaflist(
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 1}},
+				&sdcpb.TypedValue{Value: &sdcpb.TypedValue_IntVal{IntVal: 2}},
+			),
+			false,
+		},
+
+		// --- ProtoBytes ---
+		{
+			"proto bytes equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_ProtoBytes{ProtoBytes: []byte{1,2}}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_ProtoBytes{ProtoBytes: []byte{1,2}}},
+			true,
+		},
+		{
+			"proto bytes diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_ProtoBytes{ProtoBytes: []byte{1}}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_ProtoBytes{ProtoBytes: []byte{2}}},
+			false,
+		},
+
+		// --- StringVal ---
+		{
+			"string equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_StringVal{StringVal: "foo"}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_StringVal{StringVal: "foo"}},
+			true,
+		},
+		{
+			"string diff",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_StringVal{StringVal: "foo"}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_StringVal{StringVal: "bar"}},
+			false,
+		},
+
+		// --- UintVal ---
+		{
+			"uint equal",
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_UintVal{UintVal: 1}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_UintVal{UintVal: 1}},
+			true,
+		},
+		{
+			"uint diff", &sdcpb.TypedValue{Value: &sdcpb.TypedValue_UintVal{UintVal: 1}},
+			&sdcpb.TypedValue{Value: &sdcpb.TypedValue_UintVal{UintVal: 2}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EqualTypedValues(tt.t1, tt.t2)
+			if got != tt.want {
+				t.Errorf("EqualTypedValues(%v, %v) = %v, want %v", tt.t1, tt.t2, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses the following:
- adds a default value for syncing to avoid panics if the value is set <= 0
- fixes case where a NETCONF replace action on a leaflist would result in dropping non-key elements from the parent and also fixes the ordering of the elements
- incoming leaflist values were previously treated as strings causing equality checks to fail and commits to be sent to the device, leaflist values are now converted to the correct type in the tree