### PR TITLE
Config diff adjustments

### DIFF
--- a/pkg/datastore/transaction_rpc.go
+++ b/pkg/datastore/transaction_rpc.go
@@ -91,14 +91,14 @@ func (d *Datastore) replaceIntent(ctx context.Context, transaction *types.Transa
 	log.TraceFn(func() []interface{} { return []interface{}{root.String()} })
 
 	// perform validation
-	validationResult := root.Validate(ctx, d.config.Validation)
+	validationResult, validationStats := root.Validate(ctx, d.config.Validation)
 	validationResult.ErrorsStr()
 	if validationResult.HasErrors() {
 		return nil, validationResult.JoinErrors()
 	}
 
 	warnings := validationResult.WarningsStr()
-
+	log.Debug("Transaction: %s - validation stats - %s", transaction.GetTransactionId(), validationStats.String())
 	log.Infof("Transaction: %s - validation passed", transaction.GetTransactionId())
 
 	// we use the TargetSourceReplace, that adjustes the tree results in a way
@@ -218,7 +218,9 @@ func (d *Datastore) lowlevelTransactionSet(ctx context.Context, transaction *typ
 	log.Debug(root.String())
 
 	// perform validation
-	validationResult := root.Validate(ctx, d.config.Validation)
+	validationResult, validationStats := root.Validate(ctx, d.config.Validation)
+
+	log.Debugf("Transaction: %s - Validation Stats: %s", transaction.GetTransactionId(), validationStats.String())
 
 	// prepare the response struct
 	result := &sdcpb.TransactionSetResponse{

--- a/pkg/datastore/transaction_rpc.go
+++ b/pkg/datastore/transaction_rpc.go
@@ -98,7 +98,7 @@ func (d *Datastore) replaceIntent(ctx context.Context, transaction *types.Transa
 	}
 
 	warnings := validationResult.WarningsStr()
-	log.Debug("Transaction: %s - validation stats - %s", transaction.GetTransactionId(), validationStats.String())
+	log.Debugf("Transaction: %s - validation stats - %s", transaction.GetTransactionId(), validationStats.String())
 	log.Infof("Transaction: %s - validation passed", transaction.GetTransactionId())
 
 	// we use the TargetSourceReplace, that adjustes the tree results in a way

--- a/pkg/datastore/tree_operation_test.go
+++ b/pkg/datastore/tree_operation_test.go
@@ -823,7 +823,7 @@ func TestDatastore_populateTree(t *testing.T) {
 			}
 			fmt.Println(root.String())
 
-			validationResult := root.Validate(ctx, validationConfig)
+			validationResult, _ := root.Validate(ctx, validationConfig)
 
 			fmt.Printf("Validation Errors:\n%v\n", strings.Join(validationResult.ErrorsStr(), "\n"))
 			fmt.Printf("Tree:%s\n", root.String())

--- a/pkg/datastore/tree_operation_validation_test.go
+++ b/pkg/datastore/tree_operation_validation_test.go
@@ -205,7 +205,7 @@ func TestDatastore_validateTree(t *testing.T) {
 				t.Error(err)
 			}
 
-			validationResult := root.Validate(ctx, validationConfig)
+			validationResult, _ := root.Validate(ctx, validationConfig)
 
 			t.Log(root.String())
 

--- a/pkg/tree/entry.go
+++ b/pkg/tree/entry.go
@@ -75,11 +75,11 @@ type Entry interface {
 	// GetDeletes returns the cache-updates that are not updated, have no lower priority value left and hence should be deleted completely
 	GetDeletes(entries []types.DeleteEntry, aggregatePaths bool) ([]types.DeleteEntry, error)
 	// Walk takes the EntryVisitor and applies it to every Entry in the tree
-	Walk(f EntryVisitor) error
+	Walk(ctx context.Context, v EntryVisitor) error
 	// Validate kicks off validation
-	Validate(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, vCfg *config.Validation)
+	Validate(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat, vCfg *config.Validation)
 	// validateMandatory the Mandatory schema field
-	validateMandatory(ctx context.Context, resultChan chan<- *types.ValidationResultEntry)
+	validateMandatory(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat)
 	// validateMandatoryWithKeys is an internally used function that us called by validateMandatory in case
 	// the container has keys defined that need to be skipped before the mandatory attributes can be checked
 	validateMandatoryWithKeys(ctx context.Context, level int, attributes []string, choiceName string, resultChan chan<- *types.ValidationResultEntry)
@@ -157,4 +157,7 @@ type Entry interface {
 	BlameConfig(includeDefaults bool) (*sdcpb.BlameTreeElement, error)
 }
 
-type EntryVisitor func(s *sharedEntryAttributes) error
+type EntryVisitor interface {
+	Visit(ctx context.Context, s *sharedEntryAttributes) error
+	Up()
+}

--- a/pkg/tree/entry_test.go
+++ b/pkg/tree/entry_test.go
@@ -531,7 +531,7 @@ func Test_Validation_Leaflist_Min_Max(t *testing.T) {
 
 			t.Log(root.String())
 
-			validationResult := root.Validate(context.TODO(), validationConfig)
+			validationResult, _ := root.Validate(context.TODO(), validationConfig)
 
 			// check if errors are received
 			// If so, join them and return the cumulated errors
@@ -571,7 +571,7 @@ func Test_Validation_Leaflist_Min_Max(t *testing.T) {
 				}
 			}
 
-			validationResult := root.Validate(context.TODO(), validationConfig)
+			validationResult, _ := root.Validate(context.TODO(), validationConfig)
 
 			// check if errors are received
 			// If so, join them and return the cumulated errors
@@ -617,7 +617,7 @@ func Test_Validation_Leaflist_Min_Max(t *testing.T) {
 				}
 			}
 
-			validationResult := root.Validate(context.TODO(), validationConfig)
+			validationResult, _ := root.Validate(context.TODO(), validationConfig)
 
 			// check if errors are received
 			// If so, join them and return the cumulated errors
@@ -1213,7 +1213,7 @@ func Test_Validation_String_Pattern(t *testing.T) {
 				t.Error(err)
 			}
 
-			validationResult := root.Validate(context.TODO(), validationConfig)
+			validationResult, _ := root.Validate(context.TODO(), validationConfig)
 
 			// check if errors are received
 			// If so, join them and return the cumulated errors
@@ -1250,7 +1250,7 @@ func Test_Validation_String_Pattern(t *testing.T) {
 				t.Error(err)
 			}
 
-			validationResult := root.Validate(context.TODO(), validationConfig)
+			validationResult, _ := root.Validate(context.TODO(), validationConfig)
 
 			// check if errors are received
 			// If so, join them and return the cumulated errors
@@ -1346,7 +1346,7 @@ func Test_Validation_Deref(t *testing.T) {
 				t.Error(err)
 			}
 
-			validationResult := root.Validate(context.TODO(), validationConfig)
+			validationResult, _ := root.Validate(context.TODO(), validationConfig)
 
 			// check if errors are received
 			// If so, join them and return the cumulated errors

--- a/pkg/tree/sharedEntryAttributes_test.go
+++ b/pkg/tree/sharedEntryAttributes_test.go
@@ -722,7 +722,7 @@ func Test_sharedEntryAttributes_validateMandatory(t *testing.T) {
 			validationConfig.DisabledValidators.DisableAll()
 			validationConfig.DisabledValidators.Mandatory = false
 
-			validationResults := root.Validate(ctx, validationConfig)
+			validationResults, _ := root.Validate(ctx, validationConfig)
 
 			results := []string{}
 			for _, e := range validationResults {

--- a/pkg/tree/types/update_insert_flags.go
+++ b/pkg/tree/types/update_insert_flags.go
@@ -60,3 +60,16 @@ func (f *UpdateInsertFlags) Apply(le LeafEntry) *UpdateInsertFlags {
 	}
 	return f
 }
+
+func (f *UpdateInsertFlags) String() string {
+	if f.GetNewFlag() {
+		return "new"
+	}
+	if f.GetDeleteOnlyIntendedFlag() {
+		return "delete (only intended)"
+	}
+	if f.GetDeleteFlag() {
+		return "delete"
+	}
+	return "update"
+}

--- a/pkg/tree/types/validation_stats.go
+++ b/pkg/tree/types/validation_stats.go
@@ -1,0 +1,91 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+type StatType int
+
+const (
+	StatTypeMandatory StatType = iota
+	StatTypeMustStatement
+	StatTypeMinMax
+	StatTypeRange
+	StatTypePattern
+	StatTypeLength
+	StatTypeLeafRef
+	StatTypeMaxElements
+	StatTypeEnums
+)
+
+func (s StatType) String() string {
+	switch s {
+	case StatTypeMandatory:
+		return "mandatory"
+	case StatTypeMustStatement:
+		return "must-statement"
+	case StatTypeMinMax:
+		return "min/max"
+	case StatTypeRange:
+		return "range"
+	case StatTypePattern:
+		return "pattern"
+	case StatTypeLength:
+		return "length"
+	case StatTypeLeafRef:
+		return "leafref"
+	case StatTypeMaxElements:
+		return "max-elements"
+	case StatTypeEnums:
+		return "enums"
+	}
+	return ""
+}
+
+type ValidationStat struct {
+	statType StatType
+	count    uint
+}
+
+func NewValidationStat(statType StatType) *ValidationStat {
+	return &ValidationStat{
+		statType: statType,
+	}
+}
+
+func (v *ValidationStat) PlusOne() *ValidationStat {
+	v.count++
+	return v
+}
+
+func (v *ValidationStat) Set(count uint) *ValidationStat {
+	v.count = count
+	return v
+}
+
+type ValidationStatOverall struct {
+	counter map[StatType]uint
+}
+
+func NewValidationStatOverall() *ValidationStatOverall {
+	return &ValidationStatOverall{
+		counter: map[StatType]uint{},
+	}
+}
+
+func (v *ValidationStatOverall) String() string {
+	result := make([]string, 0, len(v.counter))
+	for typ, count := range v.counter {
+		result = append(result, fmt.Sprintf("%s: %d", typ.String(), count))
+	}
+	return strings.Join(result, ", ")
+}
+
+func (v *ValidationStatOverall) MergeStat(vs *ValidationStat) {
+	v.counter[vs.statType] = v.counter[vs.statType] + vs.count
+}
+
+func (v *ValidationStatOverall) GetCounter() map[StatType]uint {
+	return v.counter
+}

--- a/pkg/tree/validation_entry_leafref.go
+++ b/pkg/tree/validation_entry_leafref.go
@@ -203,7 +203,7 @@ func (s *sharedEntryAttributes) resolve_leafref_key_path(ctx context.Context, ke
 	return nil
 }
 
-func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan chan<- *types.ValidationResultEntry) {
+func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat) {
 	if s.shouldDelete() {
 		return
 	}
@@ -212,7 +212,7 @@ func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan
 	if s.schema == nil || lref == "" {
 		return
 	}
-
+	statChan <- types.NewValidationStat(types.StatTypeLeafRef).PlusOne()
 	entry, err := s.NavigateLeafRef(ctx)
 	if err != nil || len(entry) == 0 {
 		// check if the OptionalInstance (!require-instances [https://datatracker.ietf.org/doc/html/rfc7950#section-9.9.3])

--- a/pkg/tree/validation_entry_leafref_test.go
+++ b/pkg/tree/validation_entry_leafref_test.go
@@ -220,6 +220,9 @@ func Test_sharedEntryAttributes_validateLeafRefs(t *testing.T) {
 			fmt.Println(root.String())
 
 			e, err := root.Navigate(ctx, tt.lrefNodePath, true, false)
+			if err != nil {
+				t.Error(err)
+			}
 
 			s, ok := e.(*sharedEntryAttributes)
 			if !ok {
@@ -232,7 +235,8 @@ func Test_sharedEntryAttributes_validateLeafRefs(t *testing.T) {
 			}
 
 			resultChan := make(chan<- *types.ValidationResultEntry, 20)
-			s.validateLeafRefs(ctx, resultChan)
+			statChan := make(chan<- *types.ValidationStat, 20)
+			s.validateLeafRefs(ctx, resultChan, statChan)
 
 			if len(resultChan) != tt.expectedResultLen {
 				t.Fatalf("expected %d, got %d errors on leafref validation", tt.expectedResultLen, len(resultChan))

--- a/pkg/tree/validation_entry_must.go
+++ b/pkg/tree/validation_entry_must.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resultChan chan<- *types.ValidationResultEntry) {
+func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat) {
 
 	// if no schema, then there is nothing to be done, return
 	if s.schema == nil {
@@ -29,7 +29,10 @@ func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resu
 		mustStatements = schem.Field.GetMustStatements()
 	}
 
+	stat := types.NewValidationStat(types.StatTypeMustStatement)
 	for _, must := range mustStatements {
+		// meantain stats
+		stat.PlusOne()
 		// extract actual must statement
 		exprStr := must.Statement
 		// init a ProgramBuilder
@@ -68,4 +71,5 @@ func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resu
 			resultChan <- types.NewValidationResultEntry(owner, err, types.ValidationResultEntryTypeError)
 		}
 	}
+	statChan <- stat
 }

--- a/pkg/tree/validation_range_test.go
+++ b/pkg/tree/validation_range_test.go
@@ -74,7 +74,7 @@ func TestValidate_Range_SDC_Schema(t *testing.T) {
 		t.Error(err)
 	}
 
-	validationResult := root.Validate(ctx, validationConfig)
+	validationResult, _ := root.Validate(ctx, validationConfig)
 
 	t.Logf("Validation Errors:\n%s", strings.Join(validationResult.ErrorsStr(), "\n"))
 	t.Log(root.String())
@@ -186,7 +186,7 @@ func TestValidate_RangesSigned(t *testing.T) {
 				t.Error(err)
 			}
 
-			validationResult := root.Validate(ctx, validationConfig)
+			validationResult, _ := root.Validate(ctx, validationConfig)
 
 			t.Logf("Validation Errors:\n%s", strings.Join(validationResult.ErrorsStr(), "\n"))
 			t.Log(root.String())
@@ -320,7 +320,7 @@ func TestValidate_RangesUnSigned(t *testing.T) {
 			}
 
 			// run validation
-			validationResults := root.Validate(ctx, validationConfig)
+			validationResults, _ := root.Validate(ctx, validationConfig)
 
 			t.Logf("Validation Errors:\n%s", strings.Join(validationResults.ErrorsStr(), "\n"))
 			t.Log(root.String())


### PR DESCRIPTION
- Change the EntryVisitor used in the sharedEntryAttributes.Walk() from a funtion to an interface, which allows for the EntryVisitor to keep state.
- Introduce validation statistics indication how many of the different validation types where executed