### PR TITLE
add groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 version: 2
 updates:
-  -   package-ecosystem: "github-actions"
+    - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
           interval: "weekly"
-  -   package-ecosystem: "gomod"
+      groups:
+          github-actions:
+              patterns:
+                  - "*"
+
+    - package-ecosystem: "gomod"
       directory: "/"
       schedule:
           interval: "weekly"
+      groups:
+          go-dependencies:
+              patterns:
+                  - "*"


### PR DESCRIPTION
This PR causes dependabot to create one PR per dependency group, instead of one PR per dependency