### PR TITLE
Performance Optimize validation stats

### DIFF
--- a/mocks/mocktreeentry/entry.go
+++ b/mocks/mocktreeentry/entry.go
@@ -507,15 +507,15 @@ func (mr *MockEntryMockRecorder) TreeExport(owner any) *gomock.Call {
 }
 
 // Validate mocks base method.
-func (m *MockEntry) Validate(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat, vCfg *config.Validation) {
+func (m *MockEntry) Validate(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, stats *types.ValidationStats, vCfg *config.Validation) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Validate", ctx, resultChan, statChan, vCfg)
+	m.ctrl.Call(m, "Validate", ctx, resultChan, stats, vCfg)
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockEntryMockRecorder) Validate(ctx, resultChan, statChan, vCfg any) *gomock.Call {
+func (mr *MockEntryMockRecorder) Validate(ctx, resultChan, stats, vCfg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockEntry)(nil).Validate), ctx, resultChan, statChan, vCfg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockEntry)(nil).Validate), ctx, resultChan, stats, vCfg)
 }
 
 // Walk mocks base method.
@@ -689,15 +689,15 @@ func (mr *MockEntryMockRecorder) toXmlInternal(parent, onlyNewOrUpdated, honorNa
 }
 
 // validateMandatory mocks base method.
-func (m *MockEntry) validateMandatory(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat) {
+func (m *MockEntry) validateMandatory(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, stats *types.ValidationStats) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "validateMandatory", ctx, resultChan, statChan)
+	m.ctrl.Call(m, "validateMandatory", ctx, resultChan, stats)
 }
 
 // validateMandatory indicates an expected call of validateMandatory.
-func (mr *MockEntryMockRecorder) validateMandatory(ctx, resultChan, statChan any) *gomock.Call {
+func (mr *MockEntryMockRecorder) validateMandatory(ctx, resultChan, stats any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "validateMandatory", reflect.TypeOf((*MockEntry)(nil).validateMandatory), ctx, resultChan, statChan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "validateMandatory", reflect.TypeOf((*MockEntry)(nil).validateMandatory), ctx, resultChan, stats)
 }
 
 // validateMandatoryWithKeys mocks base method.

--- a/pkg/tree/entry.go
+++ b/pkg/tree/entry.go
@@ -68,9 +68,9 @@ type Entry interface {
 	// Walk takes the EntryVisitor and applies it to every Entry in the tree
 	Walk(ctx context.Context, v EntryVisitor) error
 	// Validate kicks off validation
-	Validate(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat, vCfg *config.Validation)
+	Validate(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, stats *types.ValidationStats, vCfg *config.Validation)
 	// validateMandatory the Mandatory schema field
-	validateMandatory(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat)
+	validateMandatory(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, stats *types.ValidationStats)
 	// validateMandatoryWithKeys is an internally used function that us called by validateMandatory in case
 	// the container has keys defined that need to be skipped before the mandatory attributes can be checked
 	validateMandatoryWithKeys(ctx context.Context, level int, attributes []string, choiceName string, resultChan chan<- *types.ValidationResultEntry)

--- a/pkg/tree/validation_entry_leafref.go
+++ b/pkg/tree/validation_entry_leafref.go
@@ -199,7 +199,7 @@ func (s *sharedEntryAttributes) resolve_leafref_key_path(ctx context.Context, ke
 	return nil
 }
 
-func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat) {
+func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, stats *types.ValidationStats) {
 	if s.shouldDelete() {
 		return
 	}
@@ -208,7 +208,7 @@ func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan
 	if s.schema == nil || lref == "" {
 		return
 	}
-	statChan <- types.NewValidationStat(types.StatTypeLeafRef).PlusOne()
+
 	entry, err := s.NavigateLeafRef(ctx)
 	if err != nil || len(entry) == 0 {
 		// check if the OptionalInstance (!require-instances [https://datatracker.ietf.org/doc/html/rfc7950#section-9.9.3])
@@ -242,6 +242,7 @@ func (s *sharedEntryAttributes) validateLeafRefs(ctx context.Context, resultChan
 		resultChan <- types.NewValidationResultEntry(lv.Owner(), fmt.Errorf("missing leaf reference: failed resolving leafref %s for %s to path %s LeafVariant %v", lref, s.SdcpbPath().ToXPath(false), s.SdcpbPath().ToXPath(false), lv), types.ValidationResultEntryTypeError)
 		return
 	}
+	stats.Add(types.StatTypeLeafRef, 1)
 }
 
 func generateOptionalWarning(ctx context.Context, s Entry, lref string, resultChan chan<- *types.ValidationResultEntry) {

--- a/pkg/tree/validation_entry_leafref_test.go
+++ b/pkg/tree/validation_entry_leafref_test.go
@@ -264,8 +264,8 @@ func Test_sharedEntryAttributes_validateLeafRefs(t *testing.T) {
 			}
 
 			resultChan := make(chan<- *types.ValidationResultEntry, 20)
-			statChan := make(chan<- *types.ValidationStat, 20)
-			s.validateLeafRefs(ctx, resultChan, statChan)
+			stats := types.NewValidationStats()
+			s.validateLeafRefs(ctx, resultChan, stats)
 
 			if len(resultChan) != tt.expectedResultLen {
 				t.Fatalf("expected %d, got %d errors on leafref validation", tt.expectedResultLen, len(resultChan))

--- a/pkg/tree/validation_entry_must.go
+++ b/pkg/tree/validation_entry_must.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, statChan chan<- *types.ValidationStat) {
+func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resultChan chan<- *types.ValidationResultEntry, stats *types.ValidationStats) {
 
 	// if no schema, then there is nothing to be done, return
 	if s.schema == nil {
@@ -29,10 +29,7 @@ func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resu
 		mustStatements = schem.Field.GetMustStatements()
 	}
 
-	stat := types.NewValidationStat(types.StatTypeMustStatement)
 	for _, must := range mustStatements {
-		// meantain stats
-		stat.PlusOne()
 		// extract actual must statement
 		exprStr := must.Statement
 		// init a ProgramBuilder
@@ -79,5 +76,5 @@ func (s *sharedEntryAttributes) validateMustStatements(ctx context.Context, resu
 			resultChan <- types.NewValidationResultEntry(owner, err, types.ValidationResultEntryTypeError)
 		}
 	}
-	statChan <- stat
+	stats.Add(types.StatTypeMustStatement, uint32(len(mustStatements)))
 }


### PR DESCRIPTION
Instead of creating objects per each check that are then send through a channel, a single stats object is used that allows for atomic updates of the counters.