### PR TITLE
Expose the default Deviation calc Frequency

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Prometheus                *PromConfig                     `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
 	DefaultTransactionTimeout time.Duration                   `yaml:"transaction-timeout,omitempty" json:"transaction-timeout,omitempty"`
 	Validation                *Validation                     `yaml:"validation-defaults,omitempty" json:"validation-defaults,omitempty"`
+	Deviation                 *DeviationConfig                `yaml:"deviation-defaults,omitempty" json:"deviation-defaults,omitempty"`
 }
 
 type TLS struct {
@@ -138,6 +139,13 @@ func (c *Config) validateSetDefaults() error {
 		c.Validation = &Validation{}
 	}
 	if err = c.Validation.validateSetDefaults(); err != nil {
+		return err
+	}
+
+	if c.Deviation == nil {
+		c.Deviation = &DeviationConfig{}
+	}
+	if err = c.Deviation.validateSetDefaults(); err != nil {
 		return err
 	}
 

--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -31,11 +31,30 @@ const (
 )
 
 type DatastoreConfig struct {
-	Name       string        `yaml:"name,omitempty" json:"name,omitempty"`
-	Schema     *SchemaConfig `yaml:"schema,omitempty" json:"schema,omitempty"`
-	SBI        *SBI          `yaml:"sbi,omitempty" json:"sbi,omitempty"`
-	Sync       *Sync         `yaml:"sync,omitempty" json:"sync,omitempty"`
-	Validation *Validation   `yaml:"validation,omitempty" json:"validation,omitempty"`
+	Name       string           `yaml:"name,omitempty" json:"name,omitempty"`
+	Schema     *SchemaConfig    `yaml:"schema,omitempty" json:"schema,omitempty"`
+	SBI        *SBI             `yaml:"sbi,omitempty" json:"sbi,omitempty"`
+	Sync       *Sync            `yaml:"sync,omitempty" json:"sync,omitempty"`
+	Validation *Validation      `yaml:"validation,omitempty" json:"validation,omitempty"`
+	Deviation  *DeviationConfig `yaml:"deviation,omitempty" json:"deviation,omitempty"`
+}
+
+type DeviationConfig struct {
+	Frequency time.Duration `yaml:"frequency,omitempty" json:"frequency,omitempty"`
+}
+
+func (d *DeviationConfig) validateSetDefaults() error {
+	if d.Frequency == 0 {
+		d.Frequency = 30 * time.Second
+	}
+	return nil
+}
+
+func (d *DeviationConfig) DeepCopy() *DeviationConfig {
+	result := &DeviationConfig{
+		Frequency: d.Frequency,
+	}
+	return result
 }
 
 type SBI struct {
@@ -122,7 +141,12 @@ func (ds *DatastoreConfig) ValidateSetDefaults() error {
 	if err := ds.Validation.validateSetDefaults(); err != nil {
 		return err
 	}
-
+	if ds.Deviation == nil {
+		ds.Deviation = &DeviationConfig{}
+	}
+	if err = ds.Deviation.validateSetDefaults(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -40,19 +40,19 @@ type DatastoreConfig struct {
 }
 
 type DeviationConfig struct {
-	Frequency time.Duration `yaml:"frequency,omitempty" json:"frequency,omitempty"`
+	Interval time.Duration `yaml:"interval,omitempty" json:"interval,omitempty"`
 }
 
 func (d *DeviationConfig) validateSetDefaults() error {
-	if d.Frequency == 0 {
-		d.Frequency = 30 * time.Second
+	if d.Interval == 0 {
+		d.Interval = 30 * time.Second
 	}
 	return nil
 }
 
 func (d *DeviationConfig) DeepCopy() *DeviationConfig {
 	result := &DeviationConfig{
-		Frequency: d.Frequency,
+		Interval: d.Interval,
 	}
 	return result
 }

--- a/pkg/datastore/datastore_rpc.go
+++ b/pkg/datastore/datastore_rpc.go
@@ -330,7 +330,7 @@ func (d *Datastore) StopDeviationsWatch(peer string) {
 
 func (d *Datastore) DeviationMgr(ctx context.Context, c *config.DeviationConfig) {
 	log.Infof("%s: starting deviationMgr...", d.Name())
-	ticker := time.NewTicker(c.Frequency)
+	ticker := time.NewTicker(c.Interval)
 	defer func() {
 		ticker.Stop()
 	}()

--- a/pkg/datastore/datastore_rpc.go
+++ b/pkg/datastore/datastore_rpc.go
@@ -131,7 +131,7 @@ func New(ctx context.Context, c *config.DatastoreConfig, sc schema.Client, cc ca
 			go ds.Sync(ctx)
 		}
 		// start deviation goroutine
-		ds.DeviationMgr(ctx)
+		ds.DeviationMgr(ctx, c.Deviation)
 	}()
 	return ds, nil
 }
@@ -328,9 +328,9 @@ func (d *Datastore) StopDeviationsWatch(peer string) {
 	log.Debugf("deviation watcher %s removed", peer)
 }
 
-func (d *Datastore) DeviationMgr(ctx context.Context) {
+func (d *Datastore) DeviationMgr(ctx context.Context, c *config.DeviationConfig) {
 	log.Infof("%s: starting deviationMgr...", d.Name())
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(c.Frequency)
 	defer func() {
 		ticker.Stop()
 	}()

--- a/pkg/datastore/transaction_rpc.go
+++ b/pkg/datastore/transaction_rpc.go
@@ -171,7 +171,7 @@ func (d *Datastore) LoadAllButRunningIntents(ctx context.Context, root *tree.Roo
 				continue
 			}
 			intentNames = append(intentNames, intent.GetIntentName())
-			log.Debugf("adding intent %s to tree", intent.GetIntentName())
+			log.Debugf("%s: adding intent %s to tree", d.Name(), intent.GetIntentName())
 			protoLoader := treeproto.NewProtoTreeImporter(intent)
 			log.Tracef("%s", intent.String())
 			err := root.ImportConfig(ctx, nil, protoLoader, intent.GetIntentName(), intent.GetPriority(), treetypes.NewUpdateInsertFlags())

--- a/pkg/server/datastore.go
+++ b/pkg/server/datastore.go
@@ -134,6 +134,7 @@ func (s *Server) CreateDataStore(ctx context.Context, req *sdcpb.CreateDataStore
 		},
 		SBI:        sbi,
 		Validation: s.config.Validation.DeepCopy(),
+		Deviation:  s.config.Deviation.DeepCopy(),
 	}
 	if req.GetSync() != nil {
 		dsConfig.Sync = &config.Sync{


### PR DESCRIPTION
Expose the default Deviation Calculation Frequency via the data-server.yaml

Example:

```
deviation-defaults:
  interval: 10s
```
