### PR TITLE
fix nil pointer deref

### DIFF
--- a/pkg/tree/sharedEntryAttributes.go
+++ b/pkg/tree/sharedEntryAttributes.go
@@ -1771,7 +1771,7 @@ func (s *sharedEntryAttributes) AddUpdateRecursive(ctx context.Context, path *sd
 	var err error
 	relPath := path
 
-	if path.IsRootBased {
+	if path != nil && path.IsRootBased {
 		// calculate the relative path for the add
 		relPath, err = path.AbsToRelativePath(s.SdcpbPath())
 		if err != nil {

--- a/pkg/tree/types/update.go
+++ b/pkg/tree/types/update.go
@@ -90,6 +90,12 @@ func (u *Update) ValueAsBytes() ([]byte, error) {
 }
 
 func (u *Update) Path() *sdcpb.Path {
+	if u == nil {
+		return nil
+	}
+	if u.parent == nil {
+		return nil
+	}
 	return u.parent.SdcpbPath()
 }
 


### PR DESCRIPTION
during the sync process, `writeToSyncTreeCandidate` calls `upd.Path()` which calls `u.parent.SdcpbPath()`, however `parent` is nil. This leads to a nil pointer dereference panic.

This adds extra checks to `Path()` and another check in `AddUpdateRecursive` to avoid another nil dereference