### PR TITLE
fix issue #363 mismatch xml values while deleting multiple key config

### DIFF
--- a/pkg/tree/sharedEntryAttributes.go
+++ b/pkg/tree/sharedEntryAttributes.go
@@ -485,8 +485,6 @@ func (s *sharedEntryAttributes) GetSchemaKeys() []string {
 			for _, k := range contschema.GetKeys() {
 				keys = append(keys, k.Name)
 			}
-			//possible key mismatch on multiple keys when not sorted (issue#363)
-			sort.Strings(keys)
 			return keys
 		}
 	}

--- a/pkg/tree/xml.go
+++ b/pkg/tree/xml.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
+	"sort"
 
 	"github.com/beevik/etree"
 	"github.com/sdcio/data-server/pkg/utils"
@@ -274,6 +275,9 @@ func xmlAddKeyElements(s Entry, parent *etree.Element) {
 
 	// from the parent we get the keys as slice
 	schemaKeys := parentSchema.GetSchemaKeys()
+	//issue #364: sort the slice
+	sort.Strings(schemaKeys)
+
 	var treeElem Entry = s
 	// the keys do match the levels up in the tree in reverse order
 	// hence we init i with levelUp and count down


### PR DESCRIPTION
The xml produced while deleting a config including a multiple key item may display mismatched values, leading to errors from the targeted netconf device. Sorting the keys in the getSchemaKey method of the sharedEntryAttribute fix this issue.

The xml_test.go file is updated with a test case to describe the issue and test the fix (though the fix is not in xml.go file).