### PR TITLE
Dependabot seperate group for controller-runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,5 @@ updates:
           go-dependencies:
               patterns:
                   - "*"
+              exclude-patterns:
+                  - "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
All dependencies are grouped in a single group so far. But we have seen issues with dependencies between config-server and data-server regarding controller-runtime.
Hence this PR is seperating the controller-runtime from the group such that all other dependency upgrades can be merged as a whole but controller-runtime remains seperate.