### PR TITLE
Replace deprecated grpc.DialContext with grpc.NewClient

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"os"
-	"time"
 
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
 	"github.com/spf13/cobra"
@@ -55,10 +54,7 @@ func init() {
 }
 
 func createDataClient(ctx context.Context, addr string) (sdcpb.DataServerClient, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	cc, err := grpc.DialContext(ctx, addr,
-		grpc.WithBlock(),
+	cc, err := grpc.NewClient(addr,
 		grpc.WithTransportCredentials(
 			insecure.NewCredentials(),
 		),
@@ -67,5 +63,6 @@ func createDataClient(ctx context.Context, addr string) (sdcpb.DataServerClient,
 	if err != nil {
 		return nil, err
 	}
+
 	return sdcpb.NewDataServerClient(cc), nil
 }

--- a/pkg/server/schema.go
+++ b/pkg/server/schema.go
@@ -124,14 +124,13 @@ SCHEMA_CONNECT:
 	log = log.WithValues("schema-server-address", s.config.SchemaServer.Address)
 	ctx = logf.IntoContext(ctx, log)
 
-	dialCtx, cancel := context.WithTimeout(ctx, schemaServerConnectRetry)
-	defer cancel()
-	cc, err := grpc.DialContext(dialCtx, s.config.SchemaServer.Address, opts...)
+	cc, err := grpc.NewClient(s.config.SchemaServer.Address, opts...)
 	if err != nil {
-		log.Error(err, "failed to connect to schema server")
+		log.Error(err, "failed to create schema client")
 		time.Sleep(time.Second)
 		goto SCHEMA_CONNECT
 	}
+
 	log.Info("connected to schema server")
 	s.schemaClient = schema.NewRemoteClient(cc, s.config.SchemaServer.Cache)
 }


### PR DESCRIPTION
## Summary
- replace deprecated `grpc.DialContext` with `grpc.NewClient` in the CLI client and schema client setup
- remove obsolete `WithBlock`/dial-timeout behavior from client creation
- keep connection establishment lazy (performed when first RPC is issued), aligning with `grpc.NewClient` semantics

## Files changed
- `client/cmd/root.go`
- `pkg/server/schema.go`

## Validation
- `go build ./client/... ./pkg/server/...`