### PR TITLE
Fix DeleteBranch Nil Pointer

### DIFF
--- a/pkg/datastore/sync.go
+++ b/pkg/datastore/sync.go
@@ -69,8 +69,17 @@ func (d *Datastore) ApplyToRunning(ctx context.Context, deletes []*sdcpb.Path, i
 
 	// delete entries that have zero-length leaf variant entries after remove deleted processing
 	for _, e := range rdp.GetZeroLengthLeafVariantEntries() {
-		err := ops.DeleteBranch(ctx, e.GetParent(), &sdcpb.Path{Elem: []*sdcpb.PathElem{sdcpb.NewPathElem(e.PathName(), nil)}}, consts.RunningIntentName)
-		if err != nil {
+		if e == nil {
+			log.V(logger.VDebug).Info("skipping zero-length leaf-variant branch cleanup: nil entry in processor list")
+			continue
+		}
+		p := e.GetParent()
+		if p == nil {
+			log.V(logger.VDebug).Info("skipping zero-length leaf-variant branch cleanup: entry has no parent (sync tree root)",
+				"path", e.SdcpbPath().ToXPath(false))
+			continue
+		}
+		if err := ops.DeleteBranch(ctx, p, &sdcpb.Path{Elem: []*sdcpb.PathElem{sdcpb.NewPathElem(e.PathName(), nil)}}, consts.RunningIntentName); err != nil {
 			return err
 		}
 	}

--- a/pkg/tree/ops/deletebranch.go
+++ b/pkg/tree/ops/deletebranch.go
@@ -2,14 +2,24 @@ package ops
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/sdcio/data-server/pkg/tree/api"
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
 )
 
+// ErrDeleteBranchNilEntry is returned when DeleteBranch is called with a nil tree entry.
+// Callers must validate the entry before calling.
+var ErrDeleteBranchNilEntry = errors.New("DeleteBranch: nil tree entry")
+
 func DeleteBranch(ctx context.Context, e api.Entry, path *sdcpb.Path, owner string) error {
 	var entry api.Entry
 	var err error
+
+	if e == nil {
+		return fmt.Errorf("%w: callers must pass a non-nil entry", ErrDeleteBranchNilEntry)
+	}
 
 	if path == nil {
 		return deleteBranchInternal(ctx, e, owner)
@@ -56,6 +66,9 @@ func deleteBranchInternal(ctx context.Context, e api.Entry, owner string) error 
 
 	// recurse the call
 	for childName, child := range e.GetChildMap().GetAll() {
+		if child == nil {
+			return fmt.Errorf("%w: child %q in map is nil under %s", ErrDeleteBranchNilEntry, childName, e.SdcpbPath().ToXPath(false))
+		}
 		err := DeleteBranch(ctx, child, nil, owner)
 		if err != nil {
 			return err

--- a/pkg/tree/ops/navigatesdcpbpath.go
+++ b/pkg/tree/ops/navigatesdcpbpath.go
@@ -15,6 +15,9 @@ var (
 )
 
 func NavigateSdcpbPath(ctx context.Context, e api.Entry, path *sdcpb.Path) (api.Entry, error) {
+	if e == nil {
+		return nil, fmt.Errorf("%w: nil entry", ErrNavigateSdcpbPathNotFound)
+	}
 	pathElems := path.GetElem()
 	var err error
 	if len(pathElems) == 0 {
@@ -38,6 +41,9 @@ func NavigateSdcpbPath(ctx context.Context, e api.Entry, path *sdcpb.Path) (api.
 
 		if len(pathElems) > 1 && pathElems[1].Name == ".." {
 			entry, _ = GetFirstAncestorWithSchema(e)
+		}
+		if entry == nil {
+			return nil, fmt.Errorf("%w: parent is nil at %q", ErrNavigateSdcpbPathNotFound, path.ToXPath(false))
 		}
 		return NavigateSdcpbPath(ctx, entry, path.CopyAndRemoveFirstPathElem())
 	default:

--- a/pkg/tree/root_entry.go
+++ b/pkg/tree/root_entry.go
@@ -136,6 +136,9 @@ func (r *RootEntry) GetAncestorSchema() (*sdcpb.SchemaElem, int) {
 
 // DeleteSubtree Deletes from the tree, all elements of the PathSlice defined branch of the given owner. Return values are remainsToExist and error if an error occured.
 func (r *RootEntry) DeleteBranchPaths(ctx context.Context, deletes types.DeleteEntriesList, intentName string) error {
+	if r.Entry == nil {
+		return fmt.Errorf("DeleteBranchPaths: nil root entry")
+	}
 	for _, del := range deletes {
 		err := ops.DeleteBranch(ctx, r.Entry, del.SdcpbPath(), intentName)
 		if err != nil {


### PR DESCRIPTION
## Summary
Fixes a nil-pointer panic when cleaning up zero-length leaf-variant entries after sync: `DeleteBranch` was invoked with `e.GetParent()` which is nil for the sync tree root. Also hardens path navigation and delete-branch invariants with explicit errors, caller-side checks, and debug visibility when cleanup is skipped.

## Changes
- **`pkg/datastore/sync.go`**: Before calling `DeleteBranch`, require a non-nil parent; skip (with debug logs) when the list entry is nil or has no parent (root), so the root is never deleted and `NavigateSdcpbPath` is never called with a nil entry from this path.
- **`pkg/tree/ops/navigatesdcpbpath.go`**: Reject nil starting entry; after `..` / `GetFirstAncestorWithSchema`, avoid recursing with a nil parent (return not-found style error instead of panicking).
- **`pkg/tree/ops/deletebranch.go`**: Introduce `ErrDeleteBranchNilEntry`; return a clear wrapped error if `e` is nil; guard nil children in `deleteBranchInternal` before recursion.
- **`pkg/tree/root_entry.go`**: `DeleteBranchPaths` returns an error if `r.Entry` is nil before iterating deletes.