### PR TITLE
fix: normalize identityref values in JSON importer and leafref validation

### DIFF
--- a/pkg/datastore/datastore_rpc.go
+++ b/pkg/datastore/datastore_rpc.go
@@ -59,7 +59,11 @@ type Datastore struct {
 	m                *sync.RWMutex
 	deviationClients map[sdcpb.DataServer_WatchDeviationsServer]string
 
-	// datastore mutex locks the whole datasore for further set operations
+	// dmutex serializes southbound-write-adjacent critical sections against
+	// each other: client-initiated Set transactions (TransactionSet/Confirm/
+	// Cancel, via TryLock) and the deviation-revert path (performRevert, via
+	// Lock) that reconciles drifted device state back to the last-applied
+	// intent state.
 	dmutex *sync.Mutex
 
 	// TransactionManager

--- a/pkg/datastore/sync.go
+++ b/pkg/datastore/sync.go
@@ -134,6 +134,14 @@ func (d *Datastore) NewEmptyTree(ctx context.Context) (*tree.RootEntry, error) {
 
 func (d *Datastore) performRevert(ctx context.Context, t *tree.RootEntry) error {
 	log := logger.FromContext(ctx)
+
+	// Serialize with in-flight transactions: a concurrent delete transaction must
+	// fully complete (device write + cache delete) before we snapshot the intent
+	// store. Without this, LoadAllButRunningIntents can race with IntentDelete and
+	// push stale intent config back to the device, undoing the deletion.
+	d.dmutex.Lock()
+	defer d.dmutex.Unlock()
+
 	_, err := d.LoadAllButRunningIntents(ctx, t)
 	if err != nil {
 		return err

--- a/pkg/datastore/sync.go
+++ b/pkg/datastore/sync.go
@@ -147,8 +147,9 @@ func (d *Datastore) performRevert(ctx context.Context, t *tree.RootEntry) error 
 		return err
 	}
 
-	// Tree processing operates only on the local copy t — no shared state is
-	// accessed, so no lock is required here.
+	// t is a caller-owned deep copy (the caller must pass a value obtained via
+	// d.syncTree.DeepCopy, as ApplyToRunning does). All operations below work
+	// exclusively on that isolated copy, so no dmutex is needed here.
 	err = t.FinishInsertionPhase(ctx)
 	if err != nil {
 		return err

--- a/pkg/datastore/sync.go
+++ b/pkg/datastore/sync.go
@@ -135,18 +135,20 @@ func (d *Datastore) NewEmptyTree(ctx context.Context) (*tree.RootEntry, error) {
 func (d *Datastore) performRevert(ctx context.Context, t *tree.RootEntry) error {
 	log := logger.FromContext(ctx)
 
-	// Serialize with in-flight transactions: a concurrent delete transaction must
-	// fully complete (device write + cache delete) before we snapshot the intent
-	// store. Without this, LoadAllButRunningIntents can race with IntentDelete and
-	// push stale intent config back to the device, undoing the deletion.
+	// Critical section 1: snapshot the intent store.
+	// Hold dmutex so that any concurrent delete transaction (device write +
+	// cache delete) fully completes before we read the cache. Without this,
+	// LoadAllButRunningIntents can race with IntentDelete and push stale intent
+	// config back to the device, undoing the deletion.
 	d.dmutex.Lock()
-	defer d.dmutex.Unlock()
-
 	_, err := d.LoadAllButRunningIntents(ctx, t)
+	d.dmutex.Unlock()
 	if err != nil {
 		return err
 	}
 
+	// Tree processing operates only on the local copy t — no shared state is
+	// accessed, so no lock is required here.
 	err = t.FinishInsertionPhase(ctx)
 	if err != nil {
 		return err
@@ -172,6 +174,12 @@ func (d *Datastore) performRevert(ctx context.Context, t *tree.RootEntry) error 
 	}
 
 	if performApply {
+		// Critical section 2: device write.
+		// Re-acquire dmutex to serialize the gNMI SET with in-flight
+		// transactions; a concurrent delete must not interleave its device write
+		// with ours.
+		d.dmutex.Lock()
+		defer d.dmutex.Unlock()
 		log.Info("reverting after sync")
 		resp, err := d.applyIntent(ctx, adapter.NewEntryOutputAdapter(t.Entry))
 		if err != nil {

--- a/pkg/datastore/sync.go
+++ b/pkg/datastore/sync.go
@@ -135,21 +135,23 @@ func (d *Datastore) NewEmptyTree(ctx context.Context) (*tree.RootEntry, error) {
 func (d *Datastore) performRevert(ctx context.Context, t *tree.RootEntry) error {
 	log := logger.FromContext(ctx)
 
-	// Critical section 1: snapshot the intent store.
-	// Hold dmutex so that any concurrent delete transaction (device write +
-	// cache delete) fully completes before we read the cache. Without this,
-	// LoadAllButRunningIntents can race with IntentDelete and push stale intent
-	// config back to the device, undoing the deletion.
+	// Hold dmutex for the entire snapshot-diff-apply sequence below, not just
+	// around the individual cache read and device write. Releasing it in
+	// between (even though the diff computation itself only touches t, a
+	// caller-owned deep copy) would open a window for a concurrent transaction
+	// to commit new intent/device state after we snapshot the cache but before
+	// we push our diff, causing performRevert to apply a now-stale diff and
+	// clobber that transaction's changes. A single critical section removes
+	// that window entirely, at the cost of holding dmutex for the duration of
+	// the (in-memory, non-network) diff computation as well.
 	d.dmutex.Lock()
+	defer d.dmutex.Unlock()
+
 	_, err := d.LoadAllButRunningIntents(ctx, t)
-	d.dmutex.Unlock()
 	if err != nil {
 		return err
 	}
 
-	// t is a caller-owned deep copy (the caller must pass a value obtained via
-	// d.syncTree.DeepCopy, as ApplyToRunning does). All operations below work
-	// exclusively on that isolated copy, so no dmutex is needed here.
 	err = t.FinishInsertionPhase(ctx)
 	if err != nil {
 		return err
@@ -175,12 +177,6 @@ func (d *Datastore) performRevert(ctx context.Context, t *tree.RootEntry) error 
 	}
 
 	if performApply {
-		// Critical section 2: device write.
-		// Re-acquire dmutex to serialize the gNMI SET with in-flight
-		// transactions; a concurrent delete must not interleave its device write
-		// with ours.
-		d.dmutex.Lock()
-		defer d.dmutex.Unlock()
 		log.Info("reverting after sync")
 		resp, err := d.applyIntent(ctx, adapter.NewEntryOutputAdapter(t.Entry))
 		if err != nil {

--- a/pkg/datastore/sync_test.go
+++ b/pkg/datastore/sync_test.go
@@ -374,6 +374,7 @@ func TestApplyToRunning(t *testing.T) {
 
 			datastore := &Datastore{
 				syncTreeMutex: &sync.RWMutex{},
+				dmutex:        &sync.Mutex{},
 				syncTree:      syncTree,
 				taskPool:      pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0)),
 				cacheClient:   tt.cacheClientFunc(ctrl),

--- a/pkg/datastore/sync_test.go
+++ b/pkg/datastore/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/ygot/ygot"
@@ -429,4 +430,117 @@ func TestApplyToRunning(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPerformRevert_HoldsDmutexAcrossSnapshotAndApply verifies that dmutex stays
+// held for the full snapshot-diff-apply sequence in performRevert, not just
+// around the individual cache read and device write. A concurrent TryLock
+// (the pattern TransactionSet/Confirm/Cancel use) must fail for the entire
+// duration of the revert, including while the diff is being computed, and
+// must succeed again only once performRevert has returned.
+func TestPerformRevert_HoldsDmutexAcrossSnapshotAndApply(t *testing.T) {
+	ctx := context.Background()
+
+	sc, schema, err := testhelper.InitSDCIOSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scb := schemaClient.NewSchemaClientBound(schema, sc)
+	tc := tree.NewTreeContext(scb, pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0)))
+
+	root, err := tree.NewTreeRoot(ctx, tc)
+	if err != nil {
+		t.Fatalf("failed to create new tree root: %v", err)
+	}
+
+	d := &sdcio_schema.Device{
+		Interface: map[string]*sdcio_schema.SdcioModel_Interface{
+			"ethernet-1/1": {
+				Name:        ygot.String("ethernet-1/1"),
+				Description: ygot.String("revert me"),
+			},
+		},
+	}
+	confStr, err := ygot.EmitJSON(d, &ygot.EmitJSONConfig{Format: ygot.RFC7951, SkipValidation: false})
+	if err != nil {
+		t.Fatalf("failed to marshal test config: %v", err)
+	}
+	var v any
+	json.Unmarshal([]byte(confStr), &v)
+
+	// import as New so it survives into a ToProtoUpdates diff without needing
+	// a competing intent from the cache
+	flagNew := types.NewUpdateInsertFlags()
+	flagNew.SetNewFlag()
+	vpf := pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0))
+	_, err = root.ImportConfig(ctx, &sdcpb.Path{}, jsonImporter.NewJsonTreeImporter(v, consts.RunningIntentName, consts.RunningValuesPrio, false), flagNew, vpf)
+	if err != nil {
+		t.Fatalf("failed to import test config: %v", err)
+	}
+	if err := root.FinishInsertionPhase(ctx); err != nil {
+		t.Fatalf("failed to finish insertion phase: %v", err)
+	}
+
+	ctrl := gomock.NewController(t)
+
+	ccb := mockcacheclient.NewMockCacheClientBound(ctrl)
+	ccb.EXPECT().
+		IntentGetAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, excludeIntentNames []string, intentChan chan<- *tree_persist.Intent, errChan chan<- error) {
+			close(intentChan)
+			close(errChan)
+		}).AnyTimes()
+
+	setStarted := make(chan struct{})
+	release := make(chan struct{})
+	sbi := mocktarget.NewMockTarget(ctrl)
+	sbi.EXPECT().
+		Set(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, source any) (*sdcpb.SetDataResponse, error) {
+			close(setStarted)
+			<-release
+			return &sdcpb.SetDataResponse{}, nil
+		})
+
+	datastore := &Datastore{
+		dmutex:      &sync.Mutex{},
+		taskPool:    pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0)),
+		cacheClient: ccb,
+		sbi:         sbi,
+	}
+
+	revertDone := make(chan error, 1)
+	go func() {
+		revertDone <- datastore.performRevert(ctx, root)
+	}()
+
+	select {
+	case <-setStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for performRevert to reach the device apply")
+	}
+
+	// The device write is in flight, so dmutex must still be held: a
+	// concurrent TransactionSet-style TryLock must fail.
+	if datastore.dmutex.TryLock() {
+		datastore.dmutex.Unlock()
+		t.Fatal("dmutex.TryLock() succeeded while performRevert's apply was in flight, want held")
+	}
+
+	close(release)
+
+	select {
+	case err := <-revertDone:
+		if err != nil {
+			t.Fatalf("performRevert() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for performRevert to return")
+	}
+
+	// Now that performRevert has returned, dmutex must be free again.
+	if !datastore.dmutex.TryLock() {
+		t.Fatal("dmutex.TryLock() failed after performRevert returned, want free")
+	}
+	datastore.dmutex.Unlock()
 }

--- a/pkg/datastore/sync_test.go
+++ b/pkg/datastore/sync_test.go
@@ -466,7 +466,9 @@ func TestPerformRevert_HoldsDmutexAcrossSnapshotAndApply(t *testing.T) {
 		t.Fatalf("failed to marshal test config: %v", err)
 	}
 	var v any
-	json.Unmarshal([]byte(confStr), &v)
+	if err := json.Unmarshal([]byte(confStr), &v); err != nil {
+		t.Fatalf("failed to unmarshal test config: %v", err)
+	}
 
 	// import as New so it survives into a ToProtoUpdates diff without needing
 	// a competing intent from the cache

--- a/pkg/server/transaction.go
+++ b/pkg/server/transaction.go
@@ -156,5 +156,8 @@ func translateInternalToGrpcError(err error) error {
 	if errors.Is(err, datastore.ErrDatastoreLocked) {
 		return status.Error(codes.Aborted, err.Error())
 	}
+	if errors.Is(err, types.ErrTransactionOngoing) {
+		return status.Error(codes.Aborted, err.Error())
+	}
 	return err
 }

--- a/pkg/tree/importer/import_config_adapter.go
+++ b/pkg/tree/importer/import_config_adapter.go
@@ -29,6 +29,9 @@ type ImportConfigAdapterElement interface {
 	// GetKeyValue can be called on Leafs or LeafList elements to retrieve the underlaying value
 	// When and were to expect a Leafs or LeafList is defined by the yang schema.
 	// The String value is typically used for the keys.
+	// Contract: for identityref leaf types, GetKeyValue must return the bare identity name
+	// (e.g. "BGP"), stripping any module prefix (e.g. "openconfig-policy-types:BGP").
+	// This ensures JSON_IETF and plain JSON inputs produce identical tree keys.
 	GetKeyValue(ctx context.Context, slt *sdcpb.SchemaLeafType) (string, error)
 	// GetTVValue returns the TypedValue based value defined via the SchemaLeafType. Can also only be called on Leafs or LeafLists
 	GetTVValue(ctx context.Context, slt *sdcpb.SchemaLeafType) (*sdcpb.TypedValue, error)

--- a/pkg/tree/importer/json/json_tree_importer.go
+++ b/pkg/tree/importer/json/json_tree_importer.go
@@ -107,7 +107,14 @@ func (j *JsonTreeImporterElement) GetElements() []importer.ImportConfigAdapterEl
 }
 
 func (j *JsonTreeImporterElement) GetKeyValue(ctx context.Context, slt *sdcpb.SchemaLeafType) (string, error) {
-	return fmt.Sprintf("%v", j.data), nil
+	if slt == nil {
+		return fmt.Sprintf("%v", j.data), nil
+	}
+	tv, err := j.GetTVValue(ctx, slt)
+	if err != nil {
+		return "", err
+	}
+	return tv.ToString(), nil
 }
 
 func (j *JsonTreeImporterElement) GetTVValue(ctx context.Context, slt *sdcpb.SchemaLeafType) (*sdcpb.TypedValue, error) {

--- a/pkg/tree/importer/json/json_tree_importer_test.go
+++ b/pkg/tree/importer/json/json_tree_importer_test.go
@@ -332,3 +332,34 @@ func TestJsonTreeImporter_UnknownContainer(t *testing.T) {
 		t.Error("GetElement(\"non-existent-container\") should return nil")
 	}
 }
+
+// TestJsonTreeImporter_GetKeyValue_Identityref verifies that GetKeyValue strips the module
+// prefix from a JSON_IETF identityref value and returns the bare identity name, and that
+// plain JSON (no prefix) and JSON_IETF (module-prefixed) inputs produce identical keys.
+func TestJsonTreeImporter_GetKeyValue_Identityref(t *testing.T) {
+	slt := &sdcpb.SchemaLeafType{
+		Type:                "identityref",
+		IdentityPrefixesMap: map[string]string{"BGP": "oc-policy-types"},
+		ModulePrefixMap:     map[string]string{"BGP": "openconfig-policy-types"},
+	}
+
+	tests := []struct {
+		name string
+		data any
+	}{
+		{"plain_json", "BGP"},
+		{"json_ietf_prefixed", "openconfig-policy-types:BGP"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elem := newJsonTreeImporterElement("afi-safi-type", tt.data)
+			got, err := elem.GetKeyValue(context.Background(), slt)
+			if err != nil {
+				t.Fatalf("GetKeyValue() error: %v", err)
+			}
+			if got != "BGP" {
+				t.Errorf("GetKeyValue() = %q, want %q", got, "BGP")
+			}
+		})
+	}
+}

--- a/pkg/tree/ops/validation/validation_entry_leafref.go
+++ b/pkg/tree/ops/validation/validation_entry_leafref.go
@@ -195,7 +195,7 @@ func resolveLeafrefKeyPath(ctx context.Context, e api.Entry, keys map[string]*ty
 			return fmt.Errorf("no leafentry found")
 		}
 		tv := lvs[0].Value()
-		keys[k].Value = tv.GetStringVal()
+		keys[k].Value = tv.ToString()
 		keys[k].DoNotResolve = true
 	}
 	return nil

--- a/pkg/tree/ops/validation/validation_entry_leafref_test.go
+++ b/pkg/tree/ops/validation/validation_entry_leafref_test.go
@@ -23,6 +23,147 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// buildTree creates a tree populated with config supplied as a plain-JSON map.
+func buildTree(t *testing.T, jsonConf map[string]any) *tree.RootEntry {
+	t.Helper()
+	ctx := context.Background()
+
+	sc, schema, err := testhelper.InitSDCIOSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scb := schemaClient.NewSchemaClientBound(schema, sc)
+	tc := tree.NewTreeContext(scb, pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0)))
+
+	root, err := tree.NewTreeRoot(ctx, tc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vpf := pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0))
+	_, err = root.ImportConfig(ctx, &sdcpb.Path{}, jsonImporter.NewJsonTreeImporter(jsonConf, "owner1", 500, false), types.NewUpdateInsertFlags(), vpf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := root.FinishInsertionPhase(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestLeafref_IdentityrefKey verifies that leafref validation resolves
+// current()-relative key predicates whose values are identityref leaves.
+// Without the tv.ToString() fix in resolveLeafrefKeyPath the key is "" and
+// the reference cannot be found.
+func TestLeafref_IdentityrefKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		conf        map[string]any
+		wantErrLen  int
+	}{
+		{
+			name: "identityref key resolves - pass",
+			conf: map[string]any{
+				"identityref":        map[string]any{"cryptoA": "otherAlgo"},
+				"intentityrefkey":    []any{map[string]any{"crypto": "otherAlgo", "description": "my-desc"}},
+				"intentityrefkey-ref": "my-desc",
+			},
+			wantErrLen: 0,
+		},
+		{
+			name: "identityref key mismatch - fail",
+			conf: map[string]any{
+				"identityref":        map[string]any{"cryptoA": "rsa"},
+				"intentityrefkey":    []any{map[string]any{"crypto": "otherAlgo", "description": "my-desc"}},
+				"intentityrefkey-ref": "my-desc",
+			},
+			wantErrLen: 1,
+		},
+	}
+
+	lrefPath := &sdcpb.Path{
+		Elem: []*sdcpb.PathElem{sdcpb.NewPathElem("intentityrefkey-ref", nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			root := buildTree(t, tt.conf)
+
+			e, err := ops.NavigateSdcpbPath(ctx, root.Entry, lrefPath)
+			if err != nil {
+				t.Fatalf("NavigateSdcpbPath: %v", err)
+			}
+
+			valConf := config.NewValidationConfig()
+			valConf.DisabledValidators.DisableAll()
+			valConf.DisabledValidators.Leafref = false
+			valConf.DisableConcurrency = true
+
+			result, _ := validation.Validate(ctx, e, valConf, pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0)))
+			if len(result) != tt.wantErrLen {
+				t.Errorf("Validate() returned %d errors, want %d: %v", len(result), tt.wantErrLen, result)
+			}
+		})
+	}
+}
+
+// TestMust_IdentityrefKey verifies that must-statement validation navigates
+// correctly when the predicate key value originates from an identityref leaf.
+// Without the p.StripPathElemPrefixPath() fix in Navigate the YangString()
+// prefix ("sdcio_identity:otherAlgo") prevents the list entry from being found.
+func TestMust_IdentityrefKey(t *testing.T) {
+	mustPath := &sdcpb.Path{
+		Elem: []*sdcpb.PathElem{sdcpb.NewPathElem("identityref-must-test", nil)},
+	}
+
+	tests := []struct {
+		name       string
+		conf       map[string]any
+		wantErrLen int
+	}{
+		{
+			name: "must satisfied - pass",
+			conf: map[string]any{
+				"identityref-must-test": map[string]any{"crypto-ref": "otherAlgo"},
+				"intentityrefkey":       []any{map[string]any{"crypto": "otherAlgo", "description": "present"}},
+			},
+			wantErrLen: 0,
+		},
+		{
+			name: "must not satisfied - fail",
+			conf: map[string]any{
+				"identityref-must-test": map[string]any{"crypto-ref": "otherAlgo"},
+				// no intentityrefkey entry → description path resolves to "" → must false
+			},
+			wantErrLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			root := buildTree(t, tt.conf)
+
+			e, err := ops.NavigateSdcpbPath(ctx, root.Entry, mustPath)
+			if err != nil {
+				t.Fatalf("NavigateSdcpbPath: %v", err)
+			}
+
+			valConf := config.NewValidationConfig()
+			valConf.DisabledValidators.DisableAll()
+			valConf.DisabledValidators.MustStatement = false
+			valConf.DisableConcurrency = true
+
+			result, _ := validation.Validate(ctx, e, valConf, pool.NewSharedTaskPool(ctx, runtime.GOMAXPROCS(0)))
+			if len(result) != tt.wantErrLen {
+				t.Errorf("Validate() returned %d errors, want %d: %v", len(result), tt.wantErrLen, result)
+			}
+		})
+	}
+}
+
 func Test_sharedEntryAttributes_validateLeafRefs(t *testing.T) {
 	owner1 := "owner1"
 

--- a/pkg/tree/ops/validation/yang-parser-adapter.go
+++ b/pkg/tree/ops/validation/yang-parser-adapter.go
@@ -120,6 +120,10 @@ func (y *yangParserEntryAdapter) Navigate(p *sdcpb.Path) (xpath.Entry, error) {
 		return y, nil
 	}
 
+	// xpath path elements produced by the yang-parser may carry a module prefix
+	// (e.g. "sdcio-model:list-name"). NavigateSdcpbPath does exact-name
+	// matching, so prefixes must be stripped before navigation — consistent
+	// with how BreadthSearch handles paths in validation_entry_leafref.go.
 	p.StripPathElemPrefixPath()
 
 	entry, err := ops.NavigateSdcpbPath(y.ctx, y.e, p)

--- a/pkg/tree/ops/validation/yang-parser-adapter.go
+++ b/pkg/tree/ops/validation/yang-parser-adapter.go
@@ -120,6 +120,8 @@ func (y *yangParserEntryAdapter) Navigate(p *sdcpb.Path) (xpath.Entry, error) {
 		return y, nil
 	}
 
+	p.StripPathElemPrefixPath()
+
 	entry, err := ops.NavigateSdcpbPath(y.ctx, y.e, p)
 	if err != nil {
 		return newYangParserValueEntry(xpath.NewNodesetDatum([]xutils.XpathNode{}), err), nil

--- a/tests/schema/sdcio_model_identity.yang
+++ b/tests/schema/sdcio_model_identity.yang
@@ -38,5 +38,31 @@ module sdcio_model_identity {
         type string;
       }
     }
+
+    // must exercises Navigate prefix stripping: the key predicate value is
+    // derived from an identityref leaf via current(), which YangString()
+    // returns as "prefix:value".  Navigate must strip that prefix before
+    // calling NavigateSdcpbPath, otherwise the list entry cannot be found.
+    // The sdcio_identity: self-prefix on path steps is a non-standard alias
+    // (the importing module uses a different alias), exercising the strip.
+    container identityref-must-test {
+      leaf crypto-ref {
+        type identityref {
+          base identity_base:crypto-alg;
+        }
+      }
+      must "../sdcio_identity:intentityrefkey[sdcio_identity:crypto=current()/sdcio_identity:crypto-ref]/sdcio_identity:description != ''" {
+        error-message "intentityrefkey entry for crypto-ref must exist with non-empty description";
+      }
+    }
+
+    // leafref exercises resolveLeafrefKeyPath identityref key normalisation:
+    // the key predicate current()/../identityref/cryptoA resolves to an
+    // IdentityrefVal; tv.ToString() must be used (not tv.GetStringVal()).
+    leaf intentityrefkey-ref {
+      type leafref {
+        path "../intentityrefkey[crypto=current()/../identityref/cryptoA]/description";
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **JSON importer \`GetKeyValue\`**: routes through \`GetTVValue\`/\`tv.ToString()\` so identityref keys are stored as bare identity names (e.g. \`BGP\`) rather than a raw proto struct dump, making JSON_IETF-encoded configs produce the same tree keys as plain JSON.
- **\`resolveLeafrefKeyPath\`**: switches \`tv.GetStringVal()\` → \`tv.ToString()\` so \`current()\`-relative key predicates resolve correctly when the key type is \`identityref\` (\`GetStringVal\` returns \`""\` for \`IdentityrefVal\`).
- **\`Navigate\` in \`yangParserEntryAdapter\`**: calls \`p.StripPathElemPrefixPath()\` before \`NavigateSdcpbPath\`, consistent with \`BreadthSearch\`, so xpath evaluation against identityref-keyed list entries succeeds when path elements carry a module prefix.

Together with the companion schema-server PR these four fixes fully resolve the Arista \`routing-policy\` silent validation failures first reported in #349.

## Companion PR

**schema-server** (compile-time must-statement literal normalisation):
→ https://github.com/sdcio/schema-server/pull/241