### PR TITLE
fix: remove stale default-loading hint from NavigateSdcpbPath error

### DIFF
--- a/pkg/tree/ops/navigatesdcpbpath.go
+++ b/pkg/tree/ops/navigatesdcpbpath.go
@@ -51,7 +51,7 @@ func NavigateSdcpbPath(ctx context.Context, e api.Entry, path *sdcpb.Path) (api.
 		child, exists := e.GetChilds(types.DescendMethodActiveChilds)[pathElems[0].Name]
 		if !exists {
 			pth := &sdcpb.Path{Elem: pathElems}
-			return nil, fmt.Errorf("%w: reached %v but child %v does not exist. Trying to load defaults failed", ErrNavigateSdcpbPathNotFound, e.SdcpbPath().ToXPath(false), pth.ToXPath(false))
+			return nil, fmt.Errorf("%w: reached %v but child %v does not exist", ErrNavigateSdcpbPathNotFound, e.SdcpbPath().ToXPath(false), pth.ToXPath(false))
 		}
 
 		for v := range pathElems[0].PathElemNamesKeysOnly() {


### PR DESCRIPTION
## Summary

- Removes the misleading `"Trying to load defaults failed"` suffix from the `NavigateSdcpbPath` not-found error.
- Defaults are now loaded eagerly at entry-insertion time (`NewSharedEntryAttributes` → `loadDefaults`), so no on-the-fly loading is attempted during path traversal. The old wording implied an operation that no longer exists.

Closes #178

## Test plan

- [x] Existing tests pass (no behaviour change, message-only fix)

Made with [Cursor](https://cursor.com)