### PR TITLE
ci: replace label-based CS resolution with Pairs-with body parsing

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -147,7 +147,7 @@ jobs:
           # Extract the PR number from a "Pairs-with: org/repo#NNN" line
           pairs_with_pr() {
             local repo="$1"
-            printf '%s' "$BODY" | grep -oP "(?i)Pairs-with:\s+${repo}#\K[0-9]+" | head -1
+            printf '%s' "$BODY" | grep -oP "(?i)Pairs-with:\s+${repo}#\K[0-9]+" | head -1 || true
           }
 
           # Resolve config-server: PR# → branch → full SHA (used as GHCR image tag)


### PR DESCRIPTION
## Summary

- Replaces `resolve-configserver-version` (label-based `paired-test` approach) with `resolve-paired-refs`, which parses `Pairs-with: sdcio/<repo>#<NNN>` lines from the PR body for both `config-server` and `integration-tests`.
- Adds `integration_tests_ref` workflow input and output so integration tests check out the correct branch when paired.
- **Bugfix included:** `pairs_with_pr()` now has `|| true` to suppress `grep`'s exit code 1 on no-match — without this, PRs without `Pairs-with` lines (e.g. Dependabot bumps like #465) fail `resolve-paired-refs` instead of falling back to `main`.

## Test plan

- [ ] Open a PR with `Pairs-with: sdcio/config-server#NNN` in the body — verify `configversion` resolves to the correct SHA
- [ ] Open a PR without any `Pairs-with` lines (e.g. Dependabot) — verify `resolve-paired-refs` succeeds and both outputs are `main`
- [ ] `workflow_dispatch` with explicit `configserver_version` — verify override is honoured

Made with [Cursor](https://cursor.com)