### PR TITLE
ci: skip integration tests on Dependabot and fork PRs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -210,6 +210,10 @@ jobs:
           echo "certmanagerversion=$( curl -sL https://api.github.com/repos/cert-manager/cert-manager/releases/latest | jq '.name' )" >> $GITHUB_OUTPUT
 
   integration-tests:
+    # Dependabot and fork PRs do not receive repository secrets. Without
+    # SROS25_LICENSE, containerlab SR-SIM post-deploy fails NETCONF auth
+    # (`ssh: unable to authenticate`). Unit tests still run.
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     needs: [latest-versions, pr-release, resolve-paired-refs]
     uses: sdcio/integration-tests/.github/workflows/single.yml@main
     with:


### PR DESCRIPTION
## Summary
- Dependabot (and fork) `pull_request` workflows do not receive repository secrets. `SROS25_LICENSE` is empty, so containerlab SR-SIM post-deploy fails with `ssh: unable to authenticate` during `Deploy CI-Test-Containerlab`.
- Skip the reusable integration-tests job for those PRs. Unit tests still run. Same-repo maintainer PRs, `push` to main, and `workflow_dispatch` are unchanged.
- Unblocks Dependabot PRs such as #472 (the failed run: https://github.com/sdcio/data-server/actions/runs/32831708134/job/99769324201). After this merges, rebase #472 so it picks up the skip.

## Test plan
- [ ] This PR's CI/CD run should still execute integration tests (actor is not Dependabot).
- [ ] After merge, rebase https://github.com/sdcio/data-server/pull/472 and confirm `integration-tests` is skipped and the workflow is green.
- [ ] Confirm a normal same-repo PR still runs integration tests.